### PR TITLE
Add e2e coverage for chatDeliveryAck push event, lifecycle teardown

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -144,6 +144,7 @@ def nwaku_bootstrap(shared_docker_network: str) -> Iterator[str]:
         "-p", f"127.0.0.1:{rest_host_port}:{BOOTSTRAP_REST_PORT}",
         NWAKU_IMAGE,
         "--preset=logos.dev", "--shard=1",
+        "--filter=true", "--lightpush=true",
         f"--nodekey={nodekey}",
         f"--tcp-port={BOOTSTRAP_TCP_PORT}",
         f"--nat=extip:{BOOTSTRAP_IP}",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,10 +25,10 @@ import time
 import urllib.error
 import urllib.request
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -42,13 +42,18 @@ from libs.constants import (
     RAYA_PORT,
     SARO_PORT,
 )
-from libs.helpers import ChatUser, make_chat_config, setup_chat_user
+from libs.helpers import (
+    BareChatClientFactory,
+    ChatUser,
+    ChatUserFactory,
+    make_chat_config,
+    setup_chat_user,
+)
+
+if TYPE_CHECKING:
+    from logoscore import LogoscoreClient
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
-
-
-class ChatUserFactory(Protocol):
-    def __call__(self, name: str, port: int) -> ChatUser: ...
 
 
 def _read_fixture(name: str) -> str:
@@ -227,3 +232,37 @@ def saro(chat_user_factory: ChatUserFactory) -> ChatUser:
 @pytest.fixture(scope="module")
 def raya(chat_user_factory: ChatUserFactory) -> ChatUser:
     return chat_user_factory("Raya", RAYA_PORT)
+
+
+@pytest.fixture(scope="function")
+def bare_chat_client_factory(
+    _e2e_env_or_skip: tuple[str, Path],
+    shared_docker_network: str,
+) -> Iterator[BareChatClientFactory]:
+    """Factory for zero-init clients: spawns a daemon and loads chat_module,
+    but does NOT call initChat. For negative-path tests of sync-False branches.
+
+    Function-scope: a daemon poisoned by an intentional bad initChat must not
+    leak into the next negative test. Doesn't need `nwaku_bootstrap` since
+    without initChat there's no waku binding.
+    """
+    image, modules_dir = _e2e_env_or_skip
+
+    from logoscore import LogoscoreDockerDaemon  # noqa: PLC0415
+
+    with ExitStack() as stack:
+        def _create(name: str) -> LogoscoreClient:
+            container_name = f"logoscore-{name.lower()}-{uuid.uuid4().hex[:8]}"
+            daemon = stack.enter_context(LogoscoreDockerDaemon(
+                image=image, modules_dir=modules_dir,
+                container_name=container_name,
+                network=shared_docker_network,
+                startup_timeout=60.0,
+                extra_args=["--verbose"],
+            ))
+            stack.callback(_save_logs, container_name)
+            client = daemon.client()
+            client.load_module("chat_module")
+            return client
+
+        yield _create

--- a/tests/e2e/libs/constants.py
+++ b/tests/e2e/libs/constants.py
@@ -19,3 +19,7 @@ CHAT_SHARD_ID = 1
 # namespace, so values can be reused across containers without collision.
 SARO_PORT = 60002
 RAYA_PORT = 60003
+
+# Distinct port for the lifecycle single-user test. Each container has its own
+# netns so collision is impossible, but a separate value keeps log greps unique.
+LIFECYCLE_USER_PORT = 60004

--- a/tests/e2e/libs/helpers.py
+++ b/tests/e2e/libs/helpers.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 from logoscore import LogoscoreClient
-from logos_integration_test_framework import subscribe
+from logos_integration_test_framework import EventTimeout, subscribe
 
 from libs.constants import CHAT_CLUSTER_ID, CHAT_SHARD_ID
 
@@ -71,6 +72,29 @@ def wait_event(waiter: Any, event_name: str, *, timeout: float) -> dict[str, Any
     return waiter.next(predicate=lambda e: e.get("event") == event_name, timeout=timeout)
 
 
+def assert_no_event(
+    client: LogoscoreClient,
+    *,
+    event: str,
+    trigger: Callable[[], Any],
+    timeout: float,
+    op: str,
+) -> Any:
+    """Subscribe BEFORE firing `trigger`, then assert no matching event arrives.
+
+    Returns `trigger`'s return value so the caller can also assert the sync
+    return contract.
+    """
+    with subscribe(client, MODULE, event) as w:
+        time.sleep(SUBSCRIBE_GRACE_S)
+        result = trigger()
+        try:
+            evt = w.next(predicate=lambda e: e.get("event") == event, timeout=timeout)
+        except EventTimeout:
+            return result
+        raise AssertionError(f"{op}: unexpected {event!r} event arrived: {evt!r}")
+
+
 def parse_event(event: dict[str, Any]) -> dict[str, Any]:
     """Parse the JSON payload at `arg0` into the named-fields dict the plugin emits.
 
@@ -127,6 +151,19 @@ class ChatUser:
     label: str
 
 
+class ChatUserFactory(Protocol):
+    """Type for the `chat_user_factory` fixture: spawn daemon + setup_chat_user."""
+
+    def __call__(self, name: str, port: int) -> ChatUser: ...
+
+
+class BareChatClientFactory(Protocol):
+    """Type for the `bare_chat_client_factory` fixture: daemon + load_module,
+    no initChat. Used for negative-path tests."""
+
+    def __call__(self, name: str) -> LogoscoreClient: ...
+
+
 def setup_chat_user(
     client: LogoscoreClient,
     *,
@@ -161,7 +198,14 @@ def setup_chat_user(
         client, "getId",
         event="chatGetIdResult", timeout=10.0,
     )
-    installation_name = str(parse_event(id_evt)["clientId"])
+    id_body = parse_event(id_evt)
+    # Pin the JSON shape — a `clientId` rename would KeyError below anyway;
+    # this catches the silent case where `timestamp` is dropped.
+    if set(id_body.keys()) != {"clientId", "timestamp"}:
+        raise AssertionError(
+            f"chatGetIdResult shape drift for {label}: {id_body!r}"
+        )
+    installation_name = str(id_body["clientId"])
 
     bundle_evt = call_and_wait(
         client, "createIntroBundle",

--- a/tests/e2e/test_delivery_ack.py
+++ b/tests/e2e/test_delivery_ack.py
@@ -1,0 +1,82 @@
+"""`chatDeliveryAck` push-event e2e check — the third push channel alongside
+`chatNewMessage` and `chatNewConversation`."""
+
+from __future__ import annotations
+
+import time
+
+from logos_integration_test_framework import subscribe
+
+from libs.helpers import (
+    MODULE,
+    SUBSCRIBE_GRACE_S,
+    ChatUser,
+    assert_success,
+    call_and_wait,
+    hex_encode,
+    parse_event,
+    parse_push_payload,
+    wait_event,
+)
+
+
+def test_delivery_ack_received(saro: ChatUser, raya: ChatUser) -> None:
+    # Bootstrap an X3DH conversation. We need an established conversation so
+    # `sendMessage` from Saro to Raya goes over the wire and produces a
+    # delivery-ack back to Saro.
+    with (
+        subscribe(saro.client, MODULE, "chatNewConversation") as nc_s,
+        subscribe(raya.client, MODULE, "chatNewMessage") as nm_r,
+    ):
+        time.sleep(SUBSCRIBE_GRACE_S)
+        npc_evt = call_and_wait(
+            saro.client,
+            "newPrivateConversation",
+            raya.intro_bundle,
+            hex_encode("ack-test-opener"),
+            event="chatNewPrivateConversationResult",
+            timeout=20.0,
+        )
+        assert parse_event(npc_evt)["statusCode"] == 0, (
+            f"newPrivateConversation failed: {npc_evt!r}"
+        )
+        nc_payload = parse_push_payload(
+            wait_event(nc_s, "chatNewConversation", timeout=20.0)
+        )
+        convo_id_saro = str(nc_payload["conversationId"])
+        # Drain the opener arrival on Raya so it doesn't get picked up by the
+        # next-step subscription on Saro.
+        wait_event(nm_r, "chatNewMessage", timeout=20.0)
+
+    # Two separate blocks on purpose: any opener-ack fires before this
+    # subscription mounts and is dropped — we only care about the ack for
+    # the explicit sendMessage below.
+    with subscribe(saro.client, MODULE, "chatDeliveryAck") as ack_s:
+        time.sleep(SUBSCRIBE_GRACE_S)
+        send_evt = call_and_wait(
+            saro.client,
+            "sendMessage",
+            convo_id_saro,
+            hex_encode("ack-test-body"),
+            event="chatSendMessageResult",
+            timeout=15.0,
+        )
+        assert_success(send_evt, "Saro.sendMessage (delivery-ack)")
+        ack_evt = wait_event(ack_s, "chatDeliveryAck", timeout=20.0)
+
+    ack_payload = parse_push_payload(ack_evt)
+    assert ack_payload["eventType"] == "delivery_ack", (
+        f"unexpected eventType in delivery-ack payload: {ack_payload!r}"
+    )
+    assert ack_payload["conversationId"] == convo_id_saro, (
+        f"delivery-ack conversationId mismatch: "
+        f"expected {convo_id_saro!r}, got {ack_payload['conversationId']!r}"
+    )
+    # `messageId` correlation is best-effort. `chatSendMessageResult.result`
+    # may be opaque (libchat owns the format); just verify `messageId` is
+    # present and non-empty in the ack payload, which proves the plugin
+    # propagates the field rather than dropping it.
+    assert "messageId" in ack_payload, f"delivery-ack missing messageId: {ack_payload!r}"
+    assert isinstance(ack_payload["messageId"], str) and ack_payload["messageId"], (
+        f"delivery-ack messageId is empty or non-string: {ack_payload!r}"
+    )

--- a/tests/e2e/test_delivery_ack.py
+++ b/tests/e2e/test_delivery_ack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import time
 
+import pytest
 from logos_integration_test_framework import subscribe
 
 from libs.helpers import (
@@ -20,6 +21,10 @@ from libs.helpers import (
 )
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/logos-messaging/libchat/issues/121",
+    strict=True,
+)
 def test_delivery_ack_received(saro: ChatUser, raya: ChatUser) -> None:
     # Bootstrap an X3DH conversation. We need an established conversation so
     # `sendMessage` from Saro to Raya goes over the wire and produces a

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -1,0 +1,61 @@
+"""Lifecycle e2e checks: stopChat/destroyChat reach + initChat sync-False branch."""
+
+from __future__ import annotations
+
+from libs.constants import LIFECYCLE_USER_PORT
+from libs.helpers import (
+    MODULE,
+    BareChatClientFactory,
+    ChatUserFactory,
+    assert_no_event,
+    call_and_wait,
+    parse_event,
+)
+
+
+def test_stop_destroy_clean_teardown(chat_user_factory: ChatUserFactory) -> None:
+    """Run a fully-initialised user through stopChat + destroyChat."""
+    user = chat_user_factory("Solo", LIFECYCLE_USER_PORT)
+
+    # Tight 5s deadline: a 20s `waitForFinished` timeout under event-loop
+    # flush starvation is the regression the deferred-emit fix prevents.
+    stop_evt = call_and_wait(
+        user.client,
+        "stopChat",
+        event="chatStopResult",
+        timeout=5.0,
+    )
+    stop_body = parse_event(stop_evt)
+    assert stop_body.get("success") is True, f"stopChat failed: {stop_body!r}"
+    assert set(stop_body.keys()) == {"success", "statusCode", "message", "timestamp"}, (
+        f"chatStopResult shape drift: {stop_body!r}"
+    )
+
+    # `chatDestroyResult` is documented as emitted only when the SDK supplies
+    # a message — its absence is acceptable. The load-bearing signal is the
+    # sync return + a clean container teardown afterwards.
+    assert user.client.call(MODULE, "destroyChat") is not False, (
+        "destroyChat returned False after a successful initChat"
+    )
+
+
+def test_init_chat_bad_config_returns_false_sync(
+    bare_chat_client_factory: BareChatClientFactory,
+) -> None:
+    """initChat with an unparseable config must return sync False and emit no event.
+
+    Do NOT weaken the trigger to anything libchat could parse (e.g. `"{}"`):
+    that path goes through start-up validation, not the NULL-check branch.
+    """
+    client = bare_chat_client_factory("badcfg")
+
+    ok = assert_no_event(
+        client,
+        event="chatInitResult",
+        trigger=lambda: client.call(MODULE, "initChat", "{not valid json"),
+        timeout=3.0,
+        op="initChat with malformed JSON",
+    )
+    assert ok is False, (
+        f"initChat with malformed JSON should return literal False, got {ok!r}"
+    )

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from libs.constants import LIFECYCLE_USER_PORT
 from libs.helpers import (
     MODULE,
@@ -39,6 +41,14 @@ def test_stop_destroy_clean_teardown(chat_user_factory: ChatUserFactory) -> None
     )
 
 
+@pytest.mark.xfail(
+    reason="initChat contract mismatch: chat_new is documented to return null on "
+    "failure (tests/stubs/lib/liblogoschat.h), so the plugin promises sync False + "
+    "no event for bad config. The real libchat instead returns a non-null context "
+    "for this malformed config and reports the parse error asynchronously via "
+    "chatInitResult(success=false).",
+    strict=True,
+)
 def test_init_chat_bad_config_returns_false_sync(
     bare_chat_client_factory: BareChatClientFactory,
 ) -> None:

--- a/tests/e2e/test_lifecycle.py
+++ b/tests/e2e/test_lifecycle.py
@@ -42,11 +42,7 @@ def test_stop_destroy_clean_teardown(chat_user_factory: ChatUserFactory) -> None
 
 
 @pytest.mark.xfail(
-    reason="initChat contract mismatch: chat_new is documented to return null on "
-    "failure (tests/stubs/lib/liblogoschat.h), so the plugin promises sync False + "
-    "no event for bad config. The real libchat instead returns a non-null context "
-    "for this malformed config and reports the parse error asynchronously via "
-    "chatInitResult(success=false).",
+    reason="https://github.com/logos-messaging/logos-chat/issues/90",
     strict=True,
 )
 def test_init_chat_bad_config_returns_false_sync(

--- a/tests/e2e/test_two_users_chat.py
+++ b/tests/e2e/test_two_users_chat.py
@@ -97,6 +97,13 @@ def test_two_users_can_chat(saro: ChatUser, raya: ChatUser) -> None:
         )
 
         first_msg = wait_event(nm_r, "chatNewMessage", timeout=20.0)
+        # Push events wrap libchat's payload as a *string* (consumers do two
+        # json.loads). Pin this — without the assert, a regression surfaces
+        # as a cryptic TypeError from parse_push_payload.
+        assert isinstance(parse_event(first_msg)["payload"], str), (
+            f"chatNewMessage `payload` must be a JSON-encoded string, "
+            f"got {type(parse_event(first_msg)['payload']).__name__}"
+        )
         assert extract_message_content(parse_push_payload(first_msg)) == MSG_S1
 
     _send_and_verify(raya, convo_id_raya, saro, MSG_R1, "Raya.sendMessage #1")


### PR DESCRIPTION
Closes https://github.com/logos-co/logos-chat-module/issues/34

Three new e2e tests covering plugin-RPC paths the existing happy-path doesn't reach:

  - test_delivery_ack_received — chatDeliveryAck push channel (3rd branch of event_callback).
  - test_stop_destroy_clean_teardown — stopChat / destroyChat; 5s deadline as flush-starvation canary.
  - test_init_chat_bad_config_returns_false_sync — sync-False branch of initChat.
