### PR TITLE
docs: add chat_module usage doc-test (two-instance message exchange)

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -1,0 +1,207 @@
+name: Doc-Tests
+
+# Runs chat_module's usage doc-test via the shared doctest CLI, against the commit
+# under test. The spec is an executable tutorial that builds this module's `.lgx`,
+# loads it into two headless `logoscore` daemons, and drives a real two-party
+# message round-trip over the live delivery network. Because it exercises the
+# module end to end, the job also serves as an integration check and fails if the
+# round-trip does not complete.
+#
+# Linux-only: it runs two real delivery instances on one host (distinct data dirs
+# and delivery ports). The exchange needs outbound network to reach the logos.test
+# Waku fleet, which GitHub-hosted runners have.
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+concurrency:
+  group: doctests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doctests:
+    name: doc-tests (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: logos-co
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      # Resolve the commit under test. For pull requests this is the PR's head
+      # commit (not the synthetic merge commit); for pushes it's the pushed commit.
+      # Passed to --release-for so the doc-test builds chat_module against THIS
+      # commit instead of latest master. Fork PRs are the exception: their head
+      # commit lives in the fork, not in logos-co/logos-chat-module, so nix could
+      # not fetch github:logos-co/logos-chat-module/<sha>. Blank the SHA for forks
+      # (--release-for repo= -> pins that repo to latest), so the doc-test still
+      # runs for fork PRs, just against master.
+      - name: Resolve commit under test
+        id: commit
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "Fork PR detected; doc-test will run against latest master."
+          else
+            echo "sha=${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Pre-build the closures the spec builds inline, so its bash steps hit the
+      # nix store instead of compiling under the run (and inside its poll budgets).
+      # chat_module#lgx (libchat + openssl from source) is the heavy, uncached one
+      # (it's the commit under test); logoscore / delivery / lgpm should be cachix
+      # hits. Fork PRs blank the SHA -> build the default branch, as the spec does.
+      - name: Pre-build doc-test closures
+        shell: bash
+        run: |
+          ref="github:logos-co/logos-chat-module"
+          [ -n "${{ steps.commit.outputs.sha }}" ] && ref="$ref/${{ steps.commit.outputs.sha }}"
+          nix build --no-link "$ref#lgx" -L
+          nix build --no-link "$ref#delivery_module-lgx" -L
+          nix build --no-link 'github:logos-co/logos-logoscore-cli' -L
+          nix build --no-link 'github:logos-co/logos-package-manager#cli' -L
+
+      # The runner is the shared `doctest` CLI invoked via its flake. --release-for
+      # pins the {release} placeholder for logos-chat-module to the commit under
+      # test, so `github:logos-co/logos-chat-module{release}#lgx` in the spec builds
+      # this PR/push. --continue-on-fail so the run walks every step and the report
+      # is complete; the job still exits non-zero if any step failed.
+      - name: Run doc-test
+        run: |
+          nix run github:logos-co/logos-doctest -- run \
+            doctests/chat-module-exchange.test.yaml \
+            --verbose \
+            --continue-on-fail \
+            --release-for logos-chat-module=${{ steps.commit.outputs.sha }} \
+            --report "${{ runner.temp }}/chat-module-doctest-report.html"
+
+      - name: Stage report for upload
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p report-out
+          if [ -f "${{ runner.temp }}/chat-module-doctest-report.html" ]; then
+            cp "${{ runner.temp }}/chat-module-doctest-report.html" report-out/index.html
+          else
+            echo "<h1>No report produced</h1>" > report-out/index.html
+          fi
+
+      - name: Upload execution report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chat-module-doctest-report-ubuntu-latest
+          path: report-out/index.html
+          if-no-files-found: warn
+
+      - name: Verify markdown generation
+        run: |
+          out="${{ runner.temp }}/chat-module-exchange.md"
+          nix run github:logos-co/logos-doctest -- generate \
+            doctests/chat-module-exchange.test.yaml \
+            --release-for logos-chat-module=${{ steps.commit.outputs.sha }} \
+            -o "$out"
+          test -s "$out"
+          echo "Generated markdown successfully"
+
+  publish-report:
+    name: Publish doc-test report
+    needs: doctests
+    # Run even when the doc-test fails: a failing run is exactly when you want the
+    # report. Skip on forks, where GITHUB_TOKEN can't push or comment.
+    if: ${{ always() && github.event.pull_request.head.repo.fork != true }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write          # push to the gh-pages branch
+      pull-requests: write      # post/update the PR comment
+
+    # Serialize Pages pushes so two refs can't race on the gh-pages branch.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+
+    steps:
+      - name: Download report
+        uses: actions/download-artifact@v4
+        with:
+          name: chat-module-doctest-report-ubuntu-latest
+          path: report
+
+      - name: Arrange site directory
+        id: arrange
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="pr-${{ github.event.pull_request.number }}"
+          else
+            BASE="master"
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          mkdir -p "site/$BASE"
+          if [ -f report/index.html ]; then
+            cp report/index.html "site/$BASE/index.html"
+            echo "found=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to gh-pages
+        if: steps.arrange.outputs.found != ''
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: true          # don't wipe other PRs' directories
+          commit_message: "Publish doc-test report for ${{ steps.arrange.outputs.base }} (${{ github.sha }})"
+
+      # Post the comment even if the Pages deploy had trouble, so the link is
+      # always surfaced (it resolves once Pages is enabled for the repo, one time,
+      # to deploy from the gh-pages branch).
+      - name: Comment on PR with the report link
+        if: ${{ always() && github.event_name == 'pull_request' && steps.arrange.outputs.found != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = "${{ steps.arrange.outputs.base }}";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const url = `https://${owner}.github.io/${repo}/${base}/`;
+            const marker = "<!-- chat-module-doctest-report-link -->";
+            const body =
+              `${marker}\n` +
+              `### Doc-test report\n\n` +
+              `Two headless \`chat_module\` instances built against this commit, ` +
+              `driven through the full message round-trip, rendered alongside the ` +
+              `commands actually run and their output ` +
+              `(updated each run, commit \`${context.sha.slice(0,7)}\`):\n\n` +
+              `- [Execution report](${url})\n\n` +
+              `_Pages can take a minute to update after the run finishes._`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: context.issue.number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });
+            }

--- a/README.md
+++ b/README.md
@@ -77,3 +77,20 @@ at `v0.1.2`. Load `chat_module` via `logoscore` or Basecamp.
 Bring-up is `init(instance_path, delivery_preset, tcp_port)` (empty preset →
 `logos.dev`). `init` starts delivery asynchronously and returns immediately;
 readiness arrives later as a `delivery_state_changed` event reaching `online`.
+
+## Doc-tests
+
+[`doctests/chat-module-exchange.test.yaml`](doctests/chat-module-exchange.test.yaml)
+is an executable usage tutorial: it loads `chat_module` into two headless
+[`logoscore`](https://github.com/logos-co/logos-logoscore-cli) daemons and drives
+a real, end-to-end-encrypted message round-trip between them over the live
+delivery network, documenting the module's API by example. It runs on every PR
+via [`.github/workflows/doctests.yml`](.github/workflows/doctests.yml) (the
+[shared doctest CLI](https://github.com/logos-co/logos-doctest) builds the commit
+under test), which also makes it an integration check. Run it locally against
+latest master (add `--release-for logos-chat-module=<branch-or-sha>` to pin it to
+a pushed commit instead):
+
+```bash
+nix run github:logos-co/logos-doctest -- run doctests/chat-module-exchange.test.yaml
+```

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -1,0 +1,301 @@
+name: "Headless two-instance message exchange"
+output: chat-module-exchange.md
+project_name: logos-chat-module
+release: ""
+
+intro: |
+  This tutorial shows how to use `chat_module` end to end, by example. A
+  conversation takes two parties: one shares an intro bundle, the other opens a
+  conversation from it with a first message, and a reply flows back. That
+  round-trip spans **two** independent `chat_module` instances talking over the
+  live delivery network.
+
+  So the tutorial runs two headless [`logoscore`](https://github.com/logos-co/logos-logoscore-cli)
+  daemons (Alice and Bob), each loading `chat_module` and its runtime dependency
+  `delivery_module`, and drives them through the `logoscore call` CLI: `init`,
+  `create_intro_bundle`, `create_conversation`, `send_message`, and reading the
+  thread back with `list_conversations` / `get_messages`.
+
+  `logoscore call` is request/response, so it never receives the module's push
+  events; instead each side **polls** its own persisted state (`status`,
+  `list_conversations`, `get_messages`) for what an event-driven consumer would
+  get as `delivery_state_changed` / `conversation_created` / `message_received`.
+  The exchange itself (X3DH bundle, end-to-end-encrypted messages over
+  `delivery_module`) is exactly what an application drives.
+
+what_you_build: "A verified end-to-end, end-to-end-encrypted message round-trip between two headless chat_module instances, with no UI."
+
+what_you_learn:
+  - "Run two isolated `logoscore` daemons on one host, selected by `--config-dir`"
+  - "Bring a `chat_module` instance online with `init()` and poll `status()` for `delivery_state == online`"
+  - "Drive the full round-trip over the CLI (share a bundle, open a conversation, reply) and observe receipt by polling `list_conversations` / `get_messages` instead of events"
+  - "How the `result`-bearing methods wrap their payload as `{success, value, error}` while the collection/status getters return their value directly"
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+  - "**A Linux or macOS machine.** Nix provides every toolchain (Qt, CMake, cargo, rustc) during the builds."
+  - "**`jq`** on `PATH` (used to read the JSON the CLI prints). GitHub runners ship it; locally, run the spec inside `nix shell nixpkgs#jq`."
+  - "**Network access.** The two delivery nodes discover each other over the `logos.test` Waku fleet; an isolated sandbox won't complete the exchange. Expect ~5-40s to reach Online and up to ~2 min for messages to propagate."
+
+sections:
+  - title: "Build the tools and the two modules"
+    step: true
+    text: |
+      Two tools drive the exchange: `logoscore` (the headless module runtime, which
+      also bundles `capability_module` under `logos/modules/`) and `lgpm` (the
+      package installer). Then the two modules the daemons load: `chat_module`, and
+      its runtime dependency `delivery_module`.
+
+      `chat_module` is built as `#lgx`, and `delivery_module` as
+      `#delivery_module-lgx`, a passthrough this flake re-exports from its own
+      delivery input, so the running `delivery_module` is the exact rev
+      `chat_module` is built against.
+    steps:
+      - title: "Build logoscore"
+        run: "nix build 'github:logos-co/logos-logoscore-cli' --out-link ./logos"
+        check_file: "logos/bin/logoscore"
+      - title: "Build lgpm"
+        run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
+        check_file: "lgpm/bin/lgpm"
+      - title: "Build chat_module (the commit under test)"
+        run: "nix build \"github:logos-co/logos-chat-module{release}#lgx\" -o chat-lgx"
+        code_block: "nix build 'github:logos-co/logos-chat-module#lgx' -o chat-lgx"
+        check_file: "chat-lgx"
+        post_text: |
+          `#lgx` is the installable bundle (`chat_module` staticlib + the Qt-plugin
+          glue + `metadata.json`). `{release}` is pinned to this commit in CI via
+          `--release-for logos-chat-module=<sha>`.
+      - title: "Build delivery_module (chat_module's runtime dependency)"
+        run: "nix build \"github:logos-co/logos-chat-module{release}#delivery_module-lgx\" -o delivery-lgx"
+        code_block: "nix build 'github:logos-co/logos-chat-module#delivery_module-lgx' -o delivery-lgx"
+        check_file: "delivery-lgx"
+        post_text: |
+          Built from `chat_module`'s own flake, so the running `delivery_module` is
+          the exact rev `chat_module` is built against.
+
+  - title: "Assemble the modules directory"
+    step: true
+    text: |
+      Both daemons load from one shared modules directory: the `capability_module`
+      that ships with `logoscore`, plus the two `.lgx`s installed on top.
+    steps:
+      - title: "Install the bundled and built modules"
+        run: |
+          mkdir -p modules
+          cp -RL ./logos/modules/. ./modules/
+          ./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file delivery-lgx/*.lgx
+          ./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file chat-lgx/*.lgx
+        code_block: |
+          mkdir -p modules
+          cp -RL ./logos/modules/. ./modules/                       # bundled capability_module
+          lgpm --modules-dir ./modules --allow-unsigned install --file delivery-lgx/*.lgx
+          lgpm --modules-dir ./modules --allow-unsigned install --file chat-lgx/*.lgx
+        expect_contains:
+          - "Installed to:"
+
+  - title: "Start two isolated daemons"
+    step: true
+    text: |
+      One module is a per-host singleton inside a daemon, so Alice and Bob are
+      **separate daemons**. The only thing that keeps them apart is `--config-dir`:
+      it scopes each daemon's control socket, client token, and persistence to its
+      own tree, so a `logoscore call --config-dir alice ...` always reaches Alice's
+      daemon. (Their delivery nodes are kept apart separately, by the distinct
+      `tcp_port` passed to `init` in the next step.)
+    steps:
+      - run: "mkdir -p alice-data bob-data"
+      - title: "Start Alice's daemon"
+        run: "sh -c './logos/bin/logoscore --config-dir alice -D -m ./modules > alice-daemon.log 2>&1 &'"
+        code_block: "logoscore --config-dir alice -D -m ./modules > alice-daemon.log &"
+      - title: "Start Bob's daemon"
+        run: "sh -c './logos/bin/logoscore --config-dir bob -D -m ./modules > bob-daemon.log 2>&1 &'"
+        code_block: "logoscore --config-dir bob -D -m ./modules > bob-daemon.log &"
+      - title: "Wait for both control planes to come up"
+        run: |
+          for who in alice bob; do
+            up=""
+            for i in $(seq 1 30); do
+              if ./logos/bin/logoscore --config-dir "$who" list-modules >/dev/null 2>&1; then
+                up=1; echo "${who}_DAEMON_UP"; break
+              fi
+              sleep 1
+            done
+            if [ -z "$up" ]; then echo "$who daemon never came up" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; fi
+          done
+        code_block: |
+          # poll each daemon's control plane until it answers
+          logoscore --config-dir alice list-modules
+          logoscore --config-dir bob   list-modules
+        expect_contains:
+          - "alice_DAEMON_UP"
+          - "bob_DAEMON_UP"
+      - title: "Load chat_module on each (delivery_module auto-resolves)"
+        run: |
+          ./logos/bin/logoscore --config-dir alice load-module chat_module
+          ./logos/bin/logoscore --config-dir bob   load-module chat_module
+        code_block: |
+          logoscore --config-dir alice load-module chat_module
+          logoscore --config-dir bob   load-module chat_module
+        expect_contains:
+          - "delivery_module"
+        post_text: "`chat_module` declares `dependencies: [delivery_module]`, so the host loads delivery_module on each daemon automatically."
+
+  - title: "Bring both instances online"
+    step: true
+    text: |
+      `init(instance_path, delivery_preset, tcp_port)` returns immediately and
+      kicks off the delivery bootstrap asynchronously; readiness arrives later when
+      the subscribe handshake completes and `status().delivery_state` flips to
+      `online`. Both instances are initialised **first** so their two cold Waku
+      bootstraps overlap, then each is polled; the wait is ~the slower of the two,
+      not their sum.
+    steps:
+      - title: "Initialise Alice (delivery port 60010) and Bob (60011)"
+        run: |
+          ./logos/bin/logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60010
+          ./logos/bin/logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60011
+        code_block: |
+          logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60010
+          logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60011
+        expect_contains:
+          - '"status":"ok"'
+        post_text: |
+          Distinct `instance_path` and `tcp_port` per instance: `tcp_port` is bound
+          for both the Waku TCP listener and the discv5 UDP port, so the two nodes
+          must not share it.
+      - title: "Wait for both to reach Online"
+        run: |
+          for who in alice bob; do
+            online=""
+            for i in $(seq 1 60); do
+              out=$(./logos/bin/logoscore --config-dir "$who" call chat_module status 2>/dev/null || true)
+              case "$out" in
+                *'"delivery_state":"online"'*) online=1; echo "${who}_ONLINE"; break;;
+                *'"delivery_state":"error"'*) echo "$who delivery error: $out" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1;;
+              esac
+              sleep 2
+            done
+            if [ -z "$online" ]; then echo "$who never came online" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; fi
+          done
+        code_block: |
+          # poll status() until delivery_state == online (fail fast on "error")
+          logoscore --config-dir alice call chat_module status
+          logoscore --config-dir bob   call chat_module status
+        expect_contains:
+          - "alice_ONLINE"
+          - "bob_ONLINE"
+        post_text: |
+          `status()` returns the `Status` record directly under `result`
+          (`{"status":"ok","result":{"delivery_state":"online",...}}`), unlike the
+          `result`-bearing methods below, which nest their payload one level deeper.
+
+  - title: "The round-trip"
+    step: true
+    text: |
+      Alice shares her intro bundle, Bob opens a conversation from it with a first
+      message, Alice sees it and replies, and the reply reaches Bob.
+    steps:
+      - title: "Alice creates her intro bundle"
+        run: |
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_intro_bundle)
+          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "bundle failed: $out" >&2; exit 1; }
+          echo "$out" | jq -j '.result.value' > alice-bundle.txt
+          echo "alice bundle bytes: $(wc -c < alice-bundle.txt)"
+        code_block: |
+          logoscore --config-dir alice call chat_module create_intro_bundle | jq -j '.result.value' > alice-bundle.txt
+        expect_contains:
+          - "alice bundle bytes:"
+        check_file: "alice-bundle.txt"
+        post_text: |
+          `create_intro_bundle` returns the LIDL `result` type, so its payload is at
+          `.result.value` (the X3DH prekey bundle a peer needs to start a
+          conversation with Alice), with `.result.success` / `.result.error`
+          alongside.
+      - title: "Bob opens a conversation from the bundle and sends the first message"
+        run: |
+          out=$(./logos/bin/logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob)
+          echo "$out"
+          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "create_conversation failed: $out" >&2; exit 1; }
+          echo "$out" | jq -j '.result.value' > bob-convo.txt
+          echo "bob convo: $(cat bob-convo.txt)"
+        code_block: |
+          logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob
+        expect_contains:
+          - '"status":"ok"'
+          - "bob convo:"
+        post_text: |
+          `@alice-bundle.txt` feeds the bundle file as the first argument. The
+          returned `result.value` is Bob's **local** conversation id; the first
+          message is published to Alice asynchronously.
+      - title: "Alice receives the conversation and Bob's message"
+        run: |
+          for i in $(seq 1 50); do
+            cid=$(./logos/bin/logoscore --config-dir alice call chat_module list_conversations 2>/dev/null | jq -r '.result[0].convo_id // empty')
+            if [ -n "$cid" ]; then echo "$cid" > alice-convo.txt; echo "ALICE_HAS_CONVO $cid"; break; fi
+            sleep 3
+          done
+          [ -s alice-convo.txt ] || { echo "alice never received the conversation" >&2; exit 1; }
+          cid=$(cat alice-convo.txt)
+          for i in $(seq 1 50); do
+            msgs=$(./logos/bin/logoscore --config-dir alice call chat_module get_messages "$cid" 2>/dev/null || true)
+            case "$msgs" in *'"content":"hello-from-bob"'*) echo "ALICE_GOT_BOB_MSG"; exit 0;; esac
+            sleep 3
+          done
+          echo "alice never received bob's message" >&2; exit 1
+        code_block: |
+          # Alice's local conversation id (X3DH-asymmetric: differs from Bob's)
+          logoscore --config-dir alice call chat_module list_conversations | jq -r '.result[0].convo_id'
+          # poll her thread until Bob's message lands
+          logoscore --config-dir alice call chat_module get_messages "$ALICE_CONVO"
+        expect_contains:
+          - "ALICE_HAS_CONVO"
+          - "ALICE_GOT_BOB_MSG"
+        post_text: |
+          Each side has its **own** local conversation id (X3DH gives the initiator
+          and responder different ids for the one logical conversation). Alice reads
+          hers from her own `list_conversations`; received messages are persisted
+          and surface via `get_messages` with no event subscription.
+          `list_conversations` / `get_messages` return their arrays directly under
+          `result`.
+      - title: "Alice replies"
+        run: |
+          cid=$(cat alice-convo.txt)
+          ./logos/bin/logoscore --config-dir alice call chat_module send_message "$cid" hi-bob-got-it
+        code_block: |
+          logoscore --config-dir alice call chat_module send_message "$ALICE_CONVO" hi-bob-got-it
+        expect_contains:
+          - '"status":"ok"'
+      - title: "Bob receives Alice's reply"
+        run: |
+          cid=$(cat bob-convo.txt)
+          for i in $(seq 1 50); do
+            msgs=$(./logos/bin/logoscore --config-dir bob call chat_module get_messages "$cid" 2>/dev/null || true)
+            case "$msgs" in *'"content":"hi-bob-got-it"'*) echo "BOB_GOT_REPLY"; exit 0;; esac
+            sleep 3
+          done
+          echo "bob never received alice's reply" >&2; exit 1
+        code_block: |
+          logoscore --config-dir bob call chat_module get_messages "$BOB_CONVO"
+        expect_contains:
+          - "BOB_GOT_REPLY"
+        post_text: |
+          The same path in reverse: a real bidirectional, end-to-end-encrypted
+          round-trip between two independent headless `chat_module` instances.
+
+  - title: "Stop the daemons"
+    step: true
+    steps:
+      - title: "Shut both down gracefully"
+        run: |
+          ./logos/bin/logoscore --config-dir alice stop || true
+          ./logos/bin/logoscore --config-dir bob   stop || true
+        code_block: |
+          logoscore --config-dir alice stop
+          logoscore --config-dir bob   stop
+        post_text: "Always stop through the control socket rather than killing the process group: two daemons share one shell here."

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,11 @@
           # set `m` (default, install, lidl, …) is exposed too, so the UI module
           # can consume chat_module's published .lidl contract.
           chat_module = m.default;
+
+          # The matching delivery_module .lgx, re-exported from this flake's
+          # locked delivery input, so the exact delivery_module rev chat_module is
+          # built against can be installed alongside it.
+          "delivery_module-lgx" = logos-delivery-module.packages.${system}.lgx;
         });
 
       # `nix run .#generate` materialises the two gitignored inputs `rust-lib/`


### PR DESCRIPTION
Document how to use chat_module by example: an executable logos-doctest that
walks the full lifecycle, from init() to a two-party message round-trip, so the
usage docs are verified against a real build. Because it exercises the module
end to end, it also serves as an integration check.

doctests/chat-module-exchange.test.yaml loads chat_module into two isolated
logoscore daemons (kept apart by --config-dir), brings each online over the
logos.test Waku fleet, then drives the round-trip through the `logoscore call`
CLI: one side shares an intro bundle, the other opens a conversation with a
first message, and the reply flows back. Receipt is polled via
list_conversations / get_messages, since the CLI does not receive push events.

The flake re-exports the matching delivery_module .lgx so the doc-test loads the
exact delivery rev chat_module is built against, with no separate pin to drift.
.github/workflows/doctests.yml runs the doc-test on every PR against the commit
under test and publishes the rendered tutorial as a PR comment.

