### PR TITLE
feat: bump libchat to origin/main; migrate to DirectV1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
           cache-on-failure: true
           workspaces: rust-lib
 
+      # clippy compiles the dep graph, so it runs inside the flake devShell for
+      # protoc (see flake.nix); the root flake is referenced via GITHUB_WORKSPACE.
       - name: cargo clippy
         working-directory: rust-lib
-        run: cargo clippy --locked --all-targets -- -D warnings
+        run: nix develop "$GITHUB_WORKSPACE" --command cargo clippy --locked --all-targets -- -D warnings
 
   cargo:
     name: cargo (${{ matrix.os }})
@@ -86,9 +88,11 @@ jobs:
           cache-on-failure: true
           workspaces: rust-lib
 
+      # compiles the dep graph, so it runs inside the flake devShell for protoc
+      # (see flake.nix); the root flake is referenced via GITHUB_WORKSPACE.
       - name: cargo test
         working-directory: rust-lib
-        run: cargo test --locked
+        run: nix develop "$GITHUB_WORKSPACE" --command cargo test --locked
 
   nix:
     name: nix (${{ matrix.os }})

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -5,30 +5,31 @@ release: ""
 
 intro: |
   This tutorial shows how to use `chat_module` end to end, by example. A
-  conversation takes two parties: one shares an intro bundle, the other opens a
-  conversation from it with a first message, and a reply flows back. That
+  conversation takes two parties: one shares their address, the other opens a
+  conversation with it, the first side joins, and messages flow both ways. That
   round-trip spans **two** independent `chat_module` instances talking over the
   live delivery network.
 
   So the tutorial runs two headless [`logoscore`](https://github.com/logos-co/logos-logoscore-cli)
   daemons (Alice and Bob), each loading `chat_module` and its runtime dependency
   `delivery_module`, and drives them through the `logoscore call` CLI: `init`,
-  `create_intro_bundle`, `create_conversation`, `send_message`, and reading the
-  thread back with `list_conversations` / `get_messages`.
+  `get_address`, `create_conversation`, `send_message`, and reading the thread
+  back with `list_conversations` / `get_messages`.
 
   `logoscore call` is request/response, so it never receives the module's push
   events; instead each side **polls** its own persisted state (`status`,
   `list_conversations`, `get_messages`) for what an event-driven consumer would
   get as `delivery_state_changed` / `conversation_created` / `message_received`.
-  The exchange itself (X3DH bundle, end-to-end-encrypted messages over
-  `delivery_module`) is exactly what an application drives.
+  The exchange itself (an MLS group keyed from key packages exchanged through a
+  registry, end-to-end-encrypted messages over `delivery_module`) is exactly what
+  an application drives.
 
 what_you_build: "A verified end-to-end, end-to-end-encrypted message round-trip between two headless chat_module instances, with no UI."
 
 what_you_learn:
   - "Run two isolated `logoscore` daemons on one host, selected by `--config-dir`"
   - "Bring a `chat_module` instance online with `init()` and poll `status()` for `delivery_state == online`"
-  - "Drive the full round-trip over the CLI (share a bundle, open a conversation, reply) and observe receipt by polling `list_conversations` / `get_messages` instead of events"
+  - "Drive the full round-trip over the CLI (share an address, open a conversation, reply) and observe receipt by polling `list_conversations` / `get_messages` instead of events"
   - "How the `result`-bearing methods wrap their payload as `{success, value, error}` while the collection/status getters return their value directly"
 
 prerequisites:
@@ -198,49 +199,74 @@ sections:
   - title: "The round-trip"
     step: true
     text: |
-      Alice shares her intro bundle, Bob opens a conversation from it with a first
-      message, Alice sees it and replies, and the reply reaches Bob.
+      Alice shares her address, Bob opens a DirectV1 conversation with her, Alice
+      joins via the invite, then Bob sends the first message and Alice replies — a
+      bidirectional round-trip between two independent headless instances.
     steps:
-      - title: "Alice creates her intro bundle"
+      - title: "Alice publishes her address"
         run: |
-          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_intro_bundle)
-          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "bundle failed: $out" >&2; exit 1; }
-          echo "$out" | jq -j '.result.value' > alice-bundle.txt
-          echo "alice bundle bytes: $(wc -c < alice-bundle.txt)"
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module get_address)
+          echo "$out"
+          echo "$out" | jq -j '.result' > alice-addr.txt
+          echo "alice address: $(cat alice-addr.txt)"
         code_block: |
-          logoscore --config-dir alice call chat_module create_intro_bundle | jq -j '.result.value' > alice-bundle.txt
+          logoscore --config-dir alice call chat_module get_address | jq -j '.result' > alice-addr.txt
         expect_contains:
-          - "alice bundle bytes:"
-        check_file: "alice-bundle.txt"
+          - "alice address:"
+        check_file: "alice-addr.txt"
         post_text: |
-          `create_intro_bundle` returns the LIDL `result` type, so its payload is at
-          `.result.value` (the X3DH prekey bundle a peer needs to start a
-          conversation with Alice), with `.result.success` / `.result.error`
-          alongside.
-      - title: "Bob opens a conversation from the bundle and sends the first message"
+          `get_address` returns the LIDL `tstr` type, so its payload is the string
+          directly at `.result` — Alice's installation address, what a peer needs to
+          open a conversation with her. Her key package was published to the registry
+          during `init`, so the address alone lets Bob reach her.
+      - title: "Bob opens a conversation with Alice"
         run: |
-          out=$(./logos/bin/logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob)
+          out=$(./logos/bin/logoscore --config-dir bob call chat_module create_conversation @alice-addr.txt)
           echo "$out"
           echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "create_conversation failed: $out" >&2; exit 1; }
           echo "$out" | jq -j '.result.value' > bob-convo.txt
           echo "bob convo: $(cat bob-convo.txt)"
         code_block: |
-          logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob
+          logoscore --config-dir bob call chat_module create_conversation @alice-addr.txt
         expect_contains:
           - '"status":"ok"'
           - "bob convo:"
         post_text: |
-          `@alice-bundle.txt` feeds the bundle file as the first argument. The
-          returned `result.value` is Bob's **local** conversation id; the first
-          message is published to Alice asynchronously.
-      - title: "Alice receives the conversation and Bob's message"
+          `@alice-addr.txt` feeds Alice's address as the argument. Bob fetches her
+          key package from the registry and sends her an MLS invite; `result.value`
+          is Bob's conversation id. The first message is sent separately, once Alice
+          has joined.
+      - title: "Alice joins the conversation"
         run: |
           for i in $(seq 1 50); do
             cid=$(./logos/bin/logoscore --config-dir alice call chat_module list_conversations 2>/dev/null | jq -r '.result[0].convo_id // empty')
             if [ -n "$cid" ]; then echo "$cid" > alice-convo.txt; echo "ALICE_HAS_CONVO $cid"; break; fi
             sleep 3
           done
-          [ -s alice-convo.txt ] || { echo "alice never received the conversation" >&2; exit 1; }
+          [ -s alice-convo.txt ] || { echo "alice never joined the conversation" >&2; exit 1; }
+        code_block: |
+          # poll until Alice has processed the invite and joined
+          logoscore --config-dir alice call chat_module list_conversations | jq -r '.result[0].convo_id'
+        expect_contains:
+          - "ALICE_HAS_CONVO"
+        post_text: |
+          DirectV1 is group-based, so both sides share one conversation id (the
+          group id) — unlike PrivateV1's asymmetric ids. Once the conversation
+          appears, Alice has joined and subscribed to its delivery address, so she
+          is ready to receive messages on it.
+      - title: "Bob sends the first message"
+        run: |
+          cid=$(cat bob-convo.txt)
+          ./logos/bin/logoscore --config-dir bob call chat_module send_message "$cid" hello-from-bob
+        code_block: |
+          logoscore --config-dir bob call chat_module send_message "$BOB_CONVO" hello-from-bob
+        expect_contains:
+          - '"status":"ok"'
+        post_text: |
+          Bob sends only after Alice has joined (previous step), so the message
+          reaches her subscribed thread rather than racing ahead of her join.
+      - title: "Alice receives Bob's message"
+        run: |
           cid=$(cat alice-convo.txt)
           for i in $(seq 1 50); do
             msgs=$(./logos/bin/logoscore --config-dir alice call chat_module get_messages "$cid" 2>/dev/null || true)
@@ -249,20 +275,14 @@ sections:
           done
           echo "alice never received bob's message" >&2; exit 1
         code_block: |
-          # Alice's local conversation id (X3DH-asymmetric: differs from Bob's)
-          logoscore --config-dir alice call chat_module list_conversations | jq -r '.result[0].convo_id'
-          # poll her thread until Bob's message lands
           logoscore --config-dir alice call chat_module get_messages "$ALICE_CONVO"
         expect_contains:
-          - "ALICE_HAS_CONVO"
           - "ALICE_GOT_BOB_MSG"
         post_text: |
-          Each side has its **own** local conversation id (X3DH gives the initiator
-          and responder different ids for the one logical conversation). Alice reads
-          hers from her own `list_conversations`; received messages are persisted
-          and surface via `get_messages` with no event subscription.
-          `list_conversations` / `get_messages` return their arrays directly under
-          `result`.
+          DirectV1 gives both sides the **same** conversation id (the MLS group id).
+          Received messages are persisted and surface via `get_messages` with no
+          event subscription; `list_conversations` / `get_messages` return their
+          arrays directly under `result`.
       - title: "Alice replies"
         run: |
           cid=$(cat alice-convo.txt)

--- a/flake.nix
+++ b/flake.nix
@@ -78,5 +78,18 @@
             program = "${generate}/bin/chat-module-generate";
           };
         });
+
+      # Build tools for bare `cargo` (clippy/test) that the module build needs but
+      # the CI runner image lacks: `protobuf` (protoc) for hashgraph-like-consensus's
+      # prost-build build script. Sourced from the same pinned nixpkgs as the nix
+      # build (metadata.json#nix.rust.packages.build), so `nix develop --command
+      # cargo …` uses the repo's own pin, not a separate toolchain.
+      devShells = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = [ pkgs.protobuf ];
+          };
+        });
     };
 }

--- a/metadata.json
+++ b/metadata.json
@@ -34,8 +34,9 @@
       "extra_include_dirs": []
     },
     "rust": {
+      "toolchain": "1.95.0",
       "packages": {
-        "build": ["pkg-config", "perl"],
+        "build": ["pkg-config", "perl", "protobuf"],
         "runtime": []
       }
     }

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "crypto",
  "hex",
@@ -1250,7 +1250,9 @@ name = "chat_module"
 version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
+ "hex",
  "libchat",
+ "logos-account",
  "logos-chat",
  "logos-rust-sdk",
  "serde",
@@ -1304,15 +1306,17 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "base64",
  "crossbeam-channel",
  "crypto",
  "hex",
  "libchat",
+ "logos-account",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "storage",
  "thiserror",
  "tracing",
@@ -1475,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1608,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?tag=v4.0.0#425203056d4586115beef6559b49560095a15256"
+source = "git+https://github.com/vacp2p/de-mls?branch=main#2b3eed17723d4fb12037ef8cfb1f5e8c115b09a1"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",
@@ -1733,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2887,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "alloy",
  "base64",
@@ -3224,17 +3228,18 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "crypto",
- "libchat",
+ "hex",
  "shared-traits",
+ "thiserror",
 ]
 
 [[package]]
 name = "logos-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4858,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "crypto",
 ]
@@ -4945,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git#b6fe452ea794185ff61af8f040070edb3ffe6685"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -47,6 +47,647 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.6",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb0bdd61ddff726026676450e7e6a52c68aa39d98f2d60d05ad7caaea5b8100"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1475c7edc6780b1759ccdb7960e28d29856ecbed47cfcf9e25be6a5f48b0cfb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a930a68a6f0ac19231bc2f5f0bf13fad3a26fa7df2525354890c72366c2998"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "borsh",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4546c9fae2861d4159ee3b25c44ab3edb90f21b849e86cf2086cacb1d56d8ac"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2c325d5934445209c8d22fc67d27e2cf9fb79054b8154d9e522d6a4ee3a4f7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.1.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.4",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4536d25780fcf51a338c26153c526c99649be1273600684ef10b397a207d4a"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8d765656f02f993fa0565abeb3554ccd6a0d72ea44ce0558b983136639bd6b"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a05ef5b11fad72068e6f011c21445bc5b596ac850644c4a14c30d845ce56de8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06bfe79149dd53de5b196aa3c96db0500b7cf0ed72dbd1a31bac7660bc7cc65"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41d1a11f58b456c199e04591befc64cb236fa2574a7275a07b98b173727bd39"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf028ac8bcb161ad7c104243e710cece8e1a794f65ee6c35c4c4d693c8e80ee"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5f392f2f56b2417ea6b74e1e116c6f35df5ab5fce4dc422e277d72ee18ff7b"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78de3d4ed62e2c90e16be166d0ddfe41944bb5979752703199073acf976083f2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.6",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.14.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f42ee1ef30d4d3d8b4ea5794937fccfc69e2bb1cd5bcf42d62afc57b049081"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee68bc7d713e033eeaaecb8fd13d5d8a41af97226c4388930ad459285b8e9f70"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.14.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +703,277 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base16ct"
@@ -86,10 +994,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.2",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2"
@@ -97,7 +1069,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -110,16 +1082,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -128,6 +1184,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -138,6 +1196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +1209,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -164,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "chat-proto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/chat_proto#44d5360c41d721a011d20ee69a75a85357b33b0e"
+source = "git+https://github.com/logos-messaging/chat_proto?rev=37ec98a151f6d50aab2905802ac0a896477e62ea#37ec98a151f6d50aab2905802ac0a896477e62ea"
 dependencies = [
  "prost",
 ]
@@ -172,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
 dependencies = [
  "crypto",
  "hex",
@@ -185,7 +1249,9 @@ dependencies = [
 name = "chat_module"
 version = "0.1.1"
 dependencies = [
- "client",
+ "crossbeam-channel",
+ "libchat",
+ "logos-chat",
  "logos-rust-sdk",
  "serde",
  "serde_json",
@@ -194,24 +1260,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
 
 [[package]]
-name = "client"
-version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
- "chat-sqlite",
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "components"
+version = "0.1.0"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+dependencies = [
+ "base64",
+ "crossbeam-channel",
+ "crypto",
+ "hex",
  "libchat",
+ "reqwest 0.12.28",
+ "serde",
+ "storage",
  "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -219,6 +1335,58 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-models"
@@ -238,6 +1406,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -266,15 +1467,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
  "hkdf",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "x25519-dalek",
  "xeddsa",
@@ -305,6 +1512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,11 +1536,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -341,14 +1557,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "de-mls"
+version = "4.0.0"
+source = "git+https://github.com/vacp2p/de-mls?tag=v4.0.0#425203056d4586115beef6559b49560095a15256"
+dependencies = [
+ "hashgraph-like-consensus",
+ "indexmap 2.14.0",
+ "openmls",
+ "openmls_traits 0.5.0",
+ "prost",
+ "prost-build",
+ "sha2 0.11.0",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -363,21 +1665,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -392,15 +1748,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -425,9 +1794,21 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -435,6 +1816,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -444,7 +1828,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -453,8 +1837,29 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -464,39 +1869,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ext-trait"
-version = "1.0.1"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d772df1c1a777963712fb68e014235e80863d6a91a85c4e06ba2d16243a310e5"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "ext-trait-proc_macros",
+ "libc",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "ext-trait-proc_macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "extension-traits"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537"
-dependencies = [
- "ext-trait",
-]
-
-[[package]]
-name = "extern-c"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320bea982e85d42441eb25c49b41218e7eaa2657e8f90bc4eca7437376751e23"
 
 [[package]]
 name = "fallible-iterator"
@@ -509,6 +1889,34 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "ff"
@@ -533,16 +1941,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -554,6 +2055,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -573,12 +2080,22 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
@@ -608,8 +2125,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -619,9 +2138,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -667,11 +2188,34 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -679,6 +2223,28 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashgraph-like-consensus"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b6328e1ba3b6ff66e24a018b40c6ea61a3105607755ac378003b57de7bc19d"
+dependencies = [
+ "alloy",
+ "alloy-signer",
+ "parking_lot",
+ "prost",
+ "prost-build",
+ "sha2 0.10.9",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "hashlink"
@@ -733,10 +2299,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hkdf"
@@ -753,7 +2343,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -819,10 +2409,223 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -830,6 +2633,64 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -853,6 +2714,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +2751,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -886,8 +2830,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
+ "ecdsa",
  "elliptic-curve",
+ "once_cell",
+ "serdect",
+ "sha2 0.10.9",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "leb128fmt"
@@ -904,22 +2887,29 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
 dependencies = [
+ "alloy",
  "base64",
  "blake2",
  "chat-proto",
  "chat-sqlite",
  "crypto",
+ "de-mls",
  "double-ratchets",
+ "hashgraph-like-consensus",
  "hex",
  "openmls",
+ "openmls_libcrux_crypto 0.3.1",
+ "openmls_memory_storage 0.5.0",
  "openmls_traits 0.5.0",
  "prost",
+ "rand 0.9.4",
  "rand_core 0.6.4",
- "safer-ffi",
+ "shared-traits",
  "storage",
  "thiserror",
+ "tracing",
  "x25519-dalek",
 ]
 
@@ -1187,6 +3177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,10 +3195,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos-account"
+version = "0.1.0"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+dependencies = [
+ "crypto",
+ "libchat",
+ "shared-traits",
+]
+
+[[package]]
+name = "logos-chat"
+version = "0.1.0"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+dependencies = [
+ "chat-sqlite",
+ "components",
+ "crossbeam-channel",
+ "crypto",
+ "hex",
+ "libchat",
+ "logos-account",
+ "parking_lot",
+ "shared-traits",
+ "storage",
+ "thiserror",
+ "tracing",
+]
 
 [[package]]
 name = "logos-rust-sdk"
@@ -1213,26 +3259,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro_rules_attribute"
-version = "0.1.3"
+name = "lru"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.1.3"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "num-bigint"
@@ -1243,6 +3316,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1260,6 +3339,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -1382,7 +3507,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tls_codec",
 ]
@@ -1425,6 +3550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-src"
 version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +3586,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1466,6 +3597,57 @@ checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "elliptic-curve",
  "primeorder",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1490,10 +3672,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -1517,7 +3752,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1529,10 +3764,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1541,16 +3791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1570,6 +3810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
 ]
 
 [[package]]
@@ -1613,6 +3864,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,16 +3893,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1657,6 +4017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +4031,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -1675,6 +4042,7 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -1733,6 +4101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
 ]
 
 [[package]]
@@ -1740,6 +4109,24 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "rayon"
@@ -1759,6 +4146,35 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1797,6 +4213,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +4297,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -1815,7 +4332,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1831,7 +4348,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-ident",
 ]
@@ -1848,6 +4365,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rusqlite"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,12 +4413,122 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1877,34 +4538,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "safer-ffi"
-version = "0.1.13"
+name = "rusty-fork"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435fdd58b61a6f1d8545274c1dfa458e905ff68c166e65e294a0130ef5e675bd"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
- "extern-c",
- "libc",
- "macro_rules_attribute",
- "paste",
- "safer_ffi-proc_macros",
- "scopeguard",
- "stabby",
- "uninit",
- "unwind_safe",
- "with_builtin_macros",
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
-name = "safer_ffi-proc_macros"
-version = "0.1.13"
+name = "ryu"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f25be5ba5f319542edb31925517e0380245ae37df50a9752cdbc05ef948156"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "macro_rules_attribute",
- "prettyplease 0.1.25",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1923,8 +4613,82 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
 ]
 
 [[package]]
@@ -1932,6 +4696,15 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1987,21 +4760,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "sha2-const-stable"
-version = "0.1.0"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
+name = "shared-traits"
+version = "0.1.0"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+dependencies = [
+ "crypto",
+]
 
 [[package]]
 name = "shlex"
@@ -2015,9 +4875,25 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2030,6 +4906,19 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spki"
@@ -2042,47 +4931,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "stabby"
-version = "36.2.2"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b7e94eaf470c2e76b5f15fb2fb49714471a36cc512df5ee231e62e82ec79f8"
-dependencies = [
- "rustversion",
- "stabby-abi",
-]
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "stabby-abi"
-version = "36.2.2"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc7a63b8276b54e51bfffe3d85da56e7906b2dcfcb29018a8ab666c06734c1a"
-dependencies = [
- "rustc_version",
- "rustversion",
- "sha2-const-stable",
- "stabby-macros",
-]
-
-[[package]]
-name = "stabby-macros"
-version = "36.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecb7ec5611ec93ec79d120fbe55f31bea234dc1bed1001d4a071bb688651615"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "rand 0.8.6",
- "syn 1.0.109",
-]
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#39bf26756448dd16ddff89a6c0054f79236494aa"
+source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
 dependencies = [
  "crypto",
  "thiserror",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2114,6 +5007,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +5076,70 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
@@ -2156,6 +5164,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,7 +5239,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -2186,10 +5255,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -2198,19 +5373,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "uninit"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e130f2ed46ca5d8ec13c7ff95836827f92f5f5f37fd2b2bf16f33c408d98bb6"
-dependencies = [
- "extension-traits",
-]
 
 [[package]]
 name = "universal-hash"
@@ -2218,26 +5390,51 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "unwind_safe"
-version = "0.1.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0976c77def3f1f75c4ef892a292c31c0bbe9e3d0702c63044d7c76db298171a3"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2250,6 +5447,34 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2286,6 +5511,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2337,7 +5572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2350,8 +5585,60 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2371,10 +5658,234 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2419,8 +5930,8 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
- "prettyplease 0.2.37",
+ "indexmap 2.14.0",
+ "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -2434,7 +5945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease 0.2.37",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2450,7 +5961,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2469,9 +5980,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2480,23 +5991,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "with_builtin_macros"
-version = "0.0.3"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59d55032495429b87f9d69954c6c8602e4d3f3e0a747a12dea6b0b23de685da"
-dependencies = [
- "with_builtin_macros-proc_macros",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "with_builtin_macros-proc_macros"
-version = "0.0.3"
+name = "wyz"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bd7679c15e22924f53aee34d4e448c45b674feb6129689af88593e129f8f42"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "tap",
 ]
 
 [[package]]
@@ -2518,13 +6024,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2460c9a9c9d1331ff6801e87badb517faa6b6758e5fb585eb27daf7622c6d5ad"
 dependencies = [
  "curve25519-dalek",
- "derive_more",
+ "derive_more 0.99.20",
  "ed25519",
  "ed25519-dalek",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.10.9",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2548,6 +6077,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +6111,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -20,7 +20,16 @@ resolver = "3"
 panic = "abort"
 
 [dependencies]
-client         = { git = "https://github.com/logos-messaging/libchat.git", package = "client" }
+# libchat's high-level threaded client (package renamed `client` -> `logos-chat`).
+# It owns the inbound worker that drives `Core::handle_payload` and surfaces
+# observations as `Event`s on a channel the module drains.
+logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat" }
+# The umbrella `libchat` crate, for `ChatStorage`: the builder's `storage_config`
+# panics on a bad DB, so we build the store fallibly and pass it in.
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat" }
+# The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
+# through its `Transport`, so the module's plumbing speaks the same channel type.
+crossbeam-channel = "0.5"
 # The runtime SDK, staged by the module builder (codegen.rust) at this path
 # from the same logos-rust-sdk rev its generator came from, so the generated
 # scaffold and the linked SDK never skew. The path is absent in a standalone

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -24,9 +24,14 @@ panic = "abort"
 # It owns the inbound worker that drives `Core::handle_payload` and surfaces
 # observations as `Event`s on a channel the module drains.
 logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat" }
-# The umbrella `libchat` crate, for `ChatStorage`: the builder's `storage_config`
-# panics on a bad DB, so we build the store fallibly and pass it in.
+# The umbrella `libchat` crate, for `ChatStorage`: the builder's
+# `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
 libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat" }
+# `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
+# account identity that signs this installation's device bundle and whose key is
+# the shared account address. Enable `dev` on our own dep so its availability
+# doesn't hinge on another crate happening to turn the feature on.
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"] }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"
@@ -38,6 +43,9 @@ logos-rust-sdk = { path = "../logos-rust-sdk-src" }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"
+# Hex-encodes the account verifying key as this installation's shared address,
+# and the delegate device key into the account's signed device bundle.
+hex            = "0.4"
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -40,10 +40,14 @@ module chat_module {
   ; --- identity ---
   method get_installation_name() -> tstr
   method set_installation_name(name: tstr) -> result
-  method create_intro_bundle() -> result
+  ; The local installation address, shared out-of-band so a peer can open a
+  ; conversation with this installation via create_conversation.
+  method get_address() -> tstr
 
   ; --- conversations & messages ---
-  method create_conversation(peer_intro_bundle: tstr, initial_content: tstr) -> result
+  ; Open a 1:1 conversation with the peer at peer_address (their get_address).
+  ; Sends the cryptographic invite; the first message follows via send_message.
+  method create_conversation(peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
   method send_message(convo_id: tstr, content: tstr) -> result

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -10,13 +10,14 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use client::{ChatClient, ConversationIdOwned, StorageConfig};
+use libchat::ChatStorage;
+use logos_chat::{ChatClientBuilder, StorageConfig};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
 use crate::module::{
-    module, now_ms, short_label, with_display, with_display_mut, DeliveryState, DeliveryStateKind,
-    Display, ModuleState,
+    module, now_ms, short_label, with_display, with_display_mut, Client, DeliveryState,
+    DeliveryStateKind, Display, ModuleState,
 };
 use crate::persistence::{load_state, save_state, ChatSession, DisplayMessage};
 
@@ -77,24 +78,37 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     // SQLCipher's keying requirement. A user-provided passphrase is a
     // future enhancement.
     let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
-    let storage = StorageConfig::Encrypted { path: db_path, key };
+    let storage = ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
+        .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?;
 
-    // Do the fallible *local* setup (DB open, state load) before touching
-    // delivery_module. The node's lifecycle is irreversible — createNode
-    // rejects duplicates and start is not idempotent (see the TODO in
-    // `start_delivery_bootstrap`) — so an open/load failure must abort init
-    // before any node exists; otherwise a partial init would strand a started,
-    // unowned node with no inbound worker and no way to stop it.
-    let client = ChatClient::open("logos-chat", storage, SdkDelivery)
-        .map_err(|e| InitError::Internal(format!("ChatClient::open failed: {e:?}")))?;
-    let intrinsic_name = client.installation_name().to_owned();
+    // The transport's inbound channel: the bridge worker feeds `inbound_tx` from
+    // delivery_module's `messageReceived`, the client's worker drains the rx (via
+    // `Transport::inbound`). The subscribe channel carries the core's inbound-address
+    // subscriptions to the bridge, which forwards them to delivery_module once the
+    // node is started.
+    let (inbound_tx, inbound_rx) = crossbeam_channel::unbounded();
+    let (subscribe_tx, subscribe_rx) = crossbeam_channel::unbounded();
+
+    // Do the fallible *local* setup (store open, client build) before touching
+    // delivery_module. The node's lifecycle is irreversible — createNode rejects
+    // duplicates and start is not idempotent (see the TODO in
+    // `start_delivery_bootstrap`) — so a build failure must abort init before any
+    // node exists; otherwise a partial init would strand a started, unowned node
+    // with no workers and no way to stop it. Building the client subscribes the
+    // core's inbound addresses, which queue on `subscribe_rx` until the node starts.
+    let (client, events) = ChatClientBuilder::new()
+        .transport(SdkDelivery::new(inbound_rx, subscribe_tx))
+        .storage(storage)
+        .build()
+        .map_err(|e| InitError::Internal(format!("client build failed: {e:?}")))?;
+    let intrinsic_name = client.installation_name();
 
     let state_path = PathBuf::from(format!("{instance_path}/history.json"));
     let state = load_state(&state_path);
 
     // Register listeners before the node starts — `connectionStateChanged`
     // fires during start and is not re-emitted, so a late subscribe misses it.
-    // The subscriptions are handed to the worker, which polls them; nothing
+    // The subscriptions are handed to the bridge worker, which polls them; nothing
     // arrives until `start_delivery_bootstrap` starts the node.
     let mut dm = crate::modules().delivery_module;
     let messages_sub = dm
@@ -111,10 +125,17 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     };
 
     let stop = Arc::new(AtomicBool::new(false));
-    let thread = crate::inbound::spawn(stop.clone(), messages_sub, conn_sub);
+    let inbound_thread = crate::inbound::spawn_bridge(
+        stop.clone(),
+        messages_sub,
+        conn_sub,
+        inbound_tx,
+        subscribe_rx,
+    );
+    let event_thread = crate::inbound::spawn_events(events);
 
-    // Seed the display state read by the getters (the client lives behind the
-    // other lock; its intrinsic name is cached here for get_installation_name).
+    // Seed the display state read by the getters (the client owns its identity;
+    // its intrinsic name is cached here for get_installation_name).
     with_display_mut(|d| {
         d.state = state;
         d.state_path = state_path;
@@ -125,7 +146,8 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     Ok(ModuleState {
         client,
         inbound_stop: stop,
-        inbound_thread: Some(thread),
+        inbound_thread: Some(inbound_thread),
+        event_thread: Some(event_thread),
     })
 }
 
@@ -133,17 +155,17 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
 ///
 /// Called by `lib.rs` *after* the module state is installed and the module lock
 /// is released, so the async completion callbacks acquire a free lock and never
-/// re-enter it. createNode → start → subscribe are chained — each step needs the
-/// previous (start rejects until the node exists; the content-topic subscribe
-/// needs a started node) — and every step runs off the dispatch (Qt event-loop)
-/// thread, so bootstrap, which can take tens of seconds, never blocks it.
+/// re-enter it. createNode → start are chained (start rejects until the node
+/// exists), and every step runs off the dispatch (Qt event-loop) thread, so
+/// bootstrap, which can take tens of seconds, never blocks it.
 ///
-/// Readiness (`online`) is reported only once the start/subscribe handshake
-/// completes; we do NOT use delivery's earlier `connectionStateChanged=Connected`,
-/// which fires mid-bootstrap ~tens of seconds before the transport can service a
-/// call (gating the UI on it lets actions run into the IPC timeout). The inbound
-/// worker keeps consuming connectionStateChanged for reconnect/offline handling
-/// once we're started.
+/// Readiness (`online`) is reported once the node has started; the bridge worker
+/// then forwards the core's queued inbound-address subscriptions to delivery_module
+/// (see `inbound::forward_subscriptions`). We do NOT use delivery's earlier
+/// `connectionStateChanged=Connected`, which fires mid-bootstrap ~tens of seconds
+/// before the transport can service a call (gating the UI on it lets actions run
+/// into the IPC timeout). The bridge worker keeps consuming connectionStateChanged
+/// for reconnect/offline handling once we're started.
 ///
 /// TODO: delivery_module's lifecycle should be owned by the host, not the
 /// consumer. createNode rejects duplicates and start is not idempotent, so
@@ -160,42 +182,23 @@ pub(crate) fn start_delivery_bootstrap(preset: &str, tcp_port: i32) {
     })
     .to_string();
 
-    // "delivery_address" is a placeholder segment, not a real address: the
-    // inbound worker filters loosely on the topic prefix and libchat has no
-    // accessor for our own inbound address yet.
-    // TODO: forward libchat's future `DeliveryService::subscribe(addr)` to
-    // delivery_module and drop this literal.
-    let inbound_topic = crate::delivery::content_topic_for("delivery_address");
-
     crate::modules()
         .delivery_module
         .create_node_async(&config_json, move |res| match res {
-            Ok(_) => start_node(inbound_topic),
+            Ok(_) => start_node(),
             Err(e) => set_delivery_error(format!("delivery_module.createNode failed: {e}")),
         });
 }
 
-/// Bootstrap step 2 of 3: start the node, then chain the subscribe.
-fn start_node(inbound_topic: String) {
+/// Bootstrap step 2 of 2: start the node and report readiness. Once online, the
+/// bridge worker forwards the core's queued subscriptions (see
+/// `inbound::forward_subscriptions`).
+fn start_node() {
     crate::modules()
         .delivery_module
         .start_async(move |res| match res {
-            Ok(_) => subscribe_inbound(inbound_topic),
+            Ok(_) => with_display_mut(|d| set_delivery_state(d, DeliveryStateKind::Online, "")),
             Err(e) => set_delivery_error(format!("delivery_module.start failed: {e}")),
-        });
-}
-
-/// Bootstrap step 3 of 3: subscribe to the inbound topic and report readiness.
-fn subscribe_inbound(inbound_topic: String) {
-    crate::modules()
-        .delivery_module
-        .subscribe_async(&inbound_topic, move |res| {
-            if let Err(e) = res {
-                // Receiving inbound needs this subscription; log but don't withhold
-                // readiness — sending and identity work without it, and the node started.
-                eprintln!("chat_module: delivery_module.subscribe failed: {e}");
-            }
-            with_display_mut(|d| set_delivery_state(d, DeliveryStateKind::Online, ""));
         });
 }
 
@@ -215,6 +218,12 @@ pub(crate) fn shutdown(mut ms: ModuleState) {
         // Bounded by inbound::POLL_INTERVAL; ~50 ms worst case.
         let _ = handle.join();
     }
+    // Drop the client so its worker stops and its event sender disconnects; the
+    // event consumer then ends its loop and can be joined.
+    drop(ms.client);
+    if let Some(handle) = ms.event_thread.take() {
+        let _ = handle.join();
+    }
     with_display_mut(|d| {
         // Final write; nothing left to propagate to, so log a failure.
         if let Err(e) = save_state(&d.state, &d.state_path) {
@@ -226,7 +235,7 @@ pub(crate) fn shutdown(mut ms: ModuleState) {
 
 /// Run `f` with the libchat client under the module lock, mapping "no client"
 /// (not initialised) and the unreachable poisoned lock to a [`CoreError`].
-fn with_client<R>(f: impl FnOnce(&mut ChatClient<SdkDelivery>) -> R) -> Result<R, CoreError> {
+fn with_client<R>(f: impl FnOnce(&mut Client) -> R) -> Result<R, CoreError> {
     match module().with_state_mut(|ms| f(&mut ms.client)) {
         Ok(Some(r)) => Ok(r),
         Ok(None) => Err(CoreError::NotInit),
@@ -269,14 +278,12 @@ pub(crate) fn create_intro_bundle() -> Result<String, CoreError> {
 // ── Conversations ────────────────────────────────────────────────────────────
 
 pub(crate) fn create_conversation(bundle: &str, content: &str) -> Result<String, CoreError> {
-    // libchat op under the client lock (on the dispatch thread, where the
-    // delivery replica lives). Publish is async (see SdkDelivery), so this
-    // returns without blocking on the network.
-    let convo_id =
+    // libchat op under the client lock. Publish is async (see SdkDelivery), so
+    // this returns without blocking on the network.
+    let chat_id =
         with_client(|client| client.create_conversation(bundle.as_bytes(), content.as_bytes()))?
             .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
 
-    let chat_id = convo_id.to_string();
     let ts = now_ms();
 
     let mut session = ChatSession {
@@ -338,8 +345,7 @@ pub(crate) fn send_message(convo_id: &str, content: &str) -> Result<(), CoreErro
         return Err(CoreError::NotFound);
     }
 
-    let cid: ConversationIdOwned = convo_id.into();
-    with_client(|client| client.send_message(&cid, content.as_bytes()))?
+    with_client(|client| client.send_message(convo_id, content.as_bytes()))?
         .map_err(|e| CoreError::Delivery(format!("send_message failed: {e:?}")))?;
 
     let ts = now_ms();
@@ -414,56 +420,61 @@ pub(crate) fn set_delivery_state(d: &mut Display, state: DeliveryStateKind, deta
     crate::emit_delivery_state_changed(state.as_str(), detail);
 }
 
-/// Decrypt a single inbound payload and reflect it in local state. Called from
-/// the inbound worker thread. The decrypt runs under the client lock (the slow
-/// part); recording the result runs under the display lock, so the read methods
-/// aren't held up by the decrypt.
-pub(crate) fn process_payload(payload: &[u8]) {
-    let content = match module().with_state_mut(|ms| ms.client.receive(payload)) {
-        Ok(Some(Ok(Some(content)))) => content,
-        Ok(Some(Ok(None))) => return, // protocol frame, nothing to record
-        Ok(Some(Err(e))) => {
-            eprintln!("chat_module: receive error: {e:?}");
-            return;
-        }
-        Ok(None) | Err(_) => return, // not initialised / poisoned (unreachable)
-    };
-
-    let chat_id = content.conversation_id.clone();
+/// Record a newly-observed conversation (the client's `ConversationStarted`
+/// event) and surface it. No-op for a locally-deleted or already-known
+/// conversation. Called from the event consumer thread; takes only the display
+/// lock, so it never waits on the client.
+pub(crate) fn record_conversation_started(convo_id: &str) {
     with_display_mut(|d| {
-        // libchat retains crypto state across local deletes, so we still
-        // receive decryptable payloads for deleted convos.
-        if d.state.deleted.contains(&chat_id) {
+        // libchat retains crypto state across local deletes, so we still observe
+        // events for deleted convos.
+        if d.state.deleted.contains(convo_id) || d.state.chats.contains_key(convo_id) {
             return;
         }
+        d.state.chats.insert(
+            convo_id.to_owned(),
+            ChatSession {
+                chat_id: convo_id.to_owned(),
+                nickname: None,
+                messages: Vec::new(),
+            },
+        );
+        crate::emit_conversation_created(convo_id, false, short_label(convo_id));
 
-        let is_new = content.is_new_convo && !d.state.chats.contains_key(&chat_id);
-        if is_new {
-            d.state.chats.insert(
-                chat_id.clone(),
-                ChatSession {
-                    chat_id: chat_id.clone(),
-                    nickname: None,
-                    messages: Vec::new(),
-                },
-            );
-            crate::emit_conversation_created(&chat_id, false, short_label(&chat_id));
+        // Event consumer has no caller to return to; log a failed write.
+        if let Err(e) = save_state(&d.state, &d.state_path) {
+            eprintln!("chat_module: save_state failed after conversation started: {e}");
         }
+    });
+}
 
-        if !content.data.is_empty() {
-            let text = String::from_utf8_lossy(&content.data).to_string();
-            let ts = now_ms();
-            if let Some(session) = d.state.chats.get_mut(&chat_id) {
-                session.messages.push(DisplayMessage {
-                    from_self: false,
-                    content: text.clone(),
-                    timestamp_ms: ts,
-                });
-            }
-            crate::emit_message_received(&chat_id, &text, ts as i64);
+/// Record an inbound message (the client's `MessageReceived` event) and surface
+/// it. No-op for a locally-deleted conversation; an unknown conversation is
+/// created defensively (the preceding `ConversationStarted` normally creates it
+/// first). Called from the event consumer thread; takes only the display lock.
+pub(crate) fn record_message_received(convo_id: &str, content: &[u8]) {
+    with_display_mut(|d| {
+        if d.state.deleted.contains(convo_id) {
+            return;
         }
+        let text = String::from_utf8_lossy(content).to_string();
+        let ts = now_ms();
+        let session = d
+            .state
+            .chats
+            .entry(convo_id.to_owned())
+            .or_insert_with(|| ChatSession {
+                chat_id: convo_id.to_owned(),
+                nickname: None,
+                messages: Vec::new(),
+            });
+        session.messages.push(DisplayMessage {
+            from_self: false,
+            content: text.clone(),
+            timestamp_ms: ts,
+        });
+        crate::emit_message_received(convo_id, &text, ts as i64);
 
-        // Inbound worker has no caller to return to; log a failed write.
         if let Err(e) = save_state(&d.state, &d.state_path) {
             eprintln!("chat_module: save_state failed after inbound message: {e}");
         }

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -6,20 +6,29 @@
 //! from the `ChatModule` trait implementation.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use libchat::ChatStorage;
-use logos_chat::{ChatClientBuilder, StorageConfig};
+use logos_account::TestLogosAccount;
+use logos_chat::{ChatClientBuilder, DelegateSigner, HttpRegistry, StorageConfig};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
+
+/// The devnet KeyPackage registry DirectV1 uses to publish this installation's
+/// key package and fetch a peer's. Hardcoded for now; a configurable endpoint is
+/// a future enhancement (the wiring is behind libchat's `RegistrationService`,
+/// so swapping it later is localized).
+const DEFAULT_REGISTRY_URL: &str = "https://devnet.chat-kc.logos.co";
+
 use crate::module::{
     module, now_ms, short_label, with_display, with_display_mut, Client, DeliveryState,
-    DeliveryStateKind, Display, ModuleState,
+    DeliveryStateKind, Display, ModuleState, PERSISTENCE_ENABLED,
 };
-use crate::persistence::{load_state, save_state, ChatSession, DisplayMessage};
+use crate::persistence::{load_state, save_state, AppState, ChatSession, DisplayMessage};
 
 /// Failure modes for the steady-state methods (post-`initialize`).
 #[derive(Debug, thiserror::Error)]
@@ -73,13 +82,21 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     fs::create_dir_all(instance_path)
         .map_err(|e| InitError::Internal(format!("cannot create instance_path: {e}")))?;
 
-    let db_path = format!("{instance_path}/identity.db");
-    // Static key derived from the instance path. Not secret; satisfies
-    // SQLCipher's keying requirement. A user-provided passphrase is a
-    // future enhancement.
-    let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
-    let storage = ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
-        .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?;
+    // Storage backs libchat's identity and MLS/crypto state. Ephemeral by
+    // default (see `PERSISTENCE_ENABLED`): DirectV1 has no reload path yet, so an
+    // in-memory store is honest about chats not surviving a restart. The
+    // SQLCipher path stays here, behind the switch, for when reload lands.
+    let storage = if PERSISTENCE_ENABLED {
+        let db_path = format!("{instance_path}/identity.db");
+        // Static key derived from the instance path. Not secret; satisfies
+        // SQLCipher's keying requirement. A user-provided passphrase is a
+        // future enhancement.
+        let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
+        ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
+            .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?
+    } else {
+        ChatStorage::in_memory()
+    };
 
     // The transport's inbound channel: the bridge worker feeds `inbound_tx` from
     // delivery_module's `messageReceived`, the client's worker drains the rx (via
@@ -96,15 +113,43 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     // node exists; otherwise a partial init would strand a started, unowned node
     // with no workers and no way to stop it. Building the client subscribes the
     // core's inbound addresses, which queue on `subscribe_rx` until the node starts.
-    let (client, events) = ChatClientBuilder::new()
+    //
+    // Identity is ephemeral (see `PERSISTENCE_ENABLED`): a fresh account and
+    // delegate are minted each launch. `TestLogosAccount` holds the account key;
+    // the `DelegateSigner` is a pure device keypair, and the client composes
+    // the account claim into its wire credential from the builder's account
+    // address. The account signs a bundle endorsing the delegate's device key,
+    // published to the registry's account directory below, so a peer given only
+    // the account address resolves this device's key package and opens a
+    // DirectV1 conversation. account != device: the client routes on the
+    // delegate's signer id; the account address is what we share.
+    let account = TestLogosAccount::new();
+    let account_addr = account.address();
+    let delegate = DelegateSigner::random();
+    let device_key = delegate.public_key().clone();
+    let (client, events) = ChatClientBuilder::new(account_addr.clone())
+        .ident(delegate)
         .transport(SdkDelivery::new(inbound_rx, subscribe_tx))
+        .registration(HttpRegistry::new(DEFAULT_REGISTRY_URL))
         .storage(storage)
         .build()
         .map_err(|e| InitError::Internal(format!("client build failed: {e:?}")))?;
+
+    // Endorse the delegate's device key in the registry's account directory so
+    // a peer holding only the account address resolves this device's key package.
+    // (The client registers its own key package during build.)
+    let mut directory = HttpRegistry::new(DEFAULT_REGISTRY_URL);
+    account
+        .add_delegate_signer(&mut directory, &device_key)
+        .map_err(|e| InitError::Internal(format!("publish device bundle failed: {e:?}")))?;
     let intrinsic_name = client.installation_name();
+    // The address a peer needs to open a DirectV1 conversation with us: the
+    // account address (what `client.addr()` returns). Cached in the display
+    // so `get_address` needn't take the client lock.
+    let address = account_addr;
 
     let state_path = PathBuf::from(format!("{instance_path}/history.json"));
-    let state = load_state(&state_path);
+    let state = load_display(&state_path);
 
     // Register listeners before the node starts — `connectionStateChanged`
     // fires during start and is not re-emitted, so a late subscribe misses it.
@@ -141,6 +186,7 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
         d.state_path = state_path;
         d.delivery_state = DeliveryState::initialising();
         d.intrinsic_name = intrinsic_name;
+        d.address = address;
     });
 
     Ok(ModuleState {
@@ -226,7 +272,7 @@ pub(crate) fn shutdown(mut ms: ModuleState) {
     }
     with_display_mut(|d| {
         // Final write; nothing left to propagate to, so log a failure.
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed on shutdown: {e}");
         }
         *d = Display::default();
@@ -247,8 +293,27 @@ fn with_client<R>(f: impl FnOnce(&mut Client) -> R) -> Result<R, CoreError> {
 /// so a failed write surfaces to the caller instead of being silently reported
 /// as success and then vanishing on the next `load_state`.
 fn persist(d: &Display) -> Result<(), CoreError> {
+    save_display(d).map_err(|e| CoreError::Internal(format!("save_state failed: {e}")))
+}
+
+/// Persist the display state, unless persistence is disabled (ephemeral mode),
+/// in which case this is a no-op reporting success. See
+/// [`module::PERSISTENCE_ENABLED`](crate::module::PERSISTENCE_ENABLED).
+fn save_display(d: &Display) -> io::Result<()> {
+    if !PERSISTENCE_ENABLED {
+        return Ok(());
+    }
     save_state(&d.state, &d.state_path)
-        .map_err(|e| CoreError::Internal(format!("save_state failed: {e}")))
+}
+
+/// Load the display state, or start empty when persistence is disabled
+/// (ephemeral mode). See
+/// [`module::PERSISTENCE_ENABLED`](crate::module::PERSISTENCE_ENABLED).
+fn load_display(path: &Path) -> AppState {
+    if !PERSISTENCE_ENABLED {
+        return AppState::default();
+    }
+    load_state(path)
 }
 
 // ── Identity ─────────────────────────────────────────────────────────────────
@@ -268,39 +333,36 @@ pub(crate) fn installation_name() -> String {
     with_display(crate::module::effective_installation_name)
 }
 
-pub(crate) fn create_intro_bundle() -> Result<String, CoreError> {
-    let bytes = with_client(|client| client.create_intro_bundle())?
-        .map_err(|e| CoreError::Internal(format!("create_intro_bundle failed: {e:?}")))?;
-    String::from_utf8(bytes)
-        .map_err(|_| CoreError::Internal("create_intro_bundle: bundle bytes are not UTF-8".into()))
+/// The local installation address, which a peer needs to open a DirectV1
+/// conversation with this installation (pass it to their `create_conversation`).
+/// Read from the cached display value, so it returns the empty string before
+/// `init`.
+pub(crate) fn get_address() -> String {
+    with_display(|d| d.address.clone())
 }
 
 // ── Conversations ────────────────────────────────────────────────────────────
 
-pub(crate) fn create_conversation(bundle: &str, content: &str) -> Result<String, CoreError> {
+/// Open a DirectV1 conversation with `peer_address` (the peer's installation
+/// address from their `get_address`). This sends an MLS Welcome to the peer; the
+/// first message is sent separately via `send_message` once the peer has joined.
+/// Returns the local conversation id.
+pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreError> {
     // libchat op under the client lock. Publish is async (see SdkDelivery), so
     // this returns without blocking on the network.
-    let chat_id =
-        with_client(|client| client.create_conversation(bundle.as_bytes(), content.as_bytes()))?
-            .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
+    let chat_id = with_client(|client| client.create_direct_conversation(peer_address))?
+        .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
 
-    let ts = now_ms();
-
-    let mut session = ChatSession {
-        chat_id: chat_id.clone(),
-        nickname: None,
-        messages: Vec::new(),
-    };
-    if !content.is_empty() {
-        session.messages.push(DisplayMessage {
-            from_self: true,
-            content: content.to_string(),
-            timestamp_ms: ts,
-        });
-    }
     let peer_label = short_label(&chat_id).to_owned();
     with_display_mut(|d| {
-        d.state.chats.insert(chat_id.clone(), session);
+        d.state.chats.insert(
+            chat_id.clone(),
+            ChatSession {
+                chat_id: chat_id.clone(),
+                nickname: None,
+                messages: Vec::new(),
+            },
+        );
         persist(d)
     })?;
     crate::emit_conversation_created(&chat_id, true, &peer_label);
@@ -442,7 +504,7 @@ pub(crate) fn record_conversation_started(convo_id: &str) {
         crate::emit_conversation_created(convo_id, false, short_label(convo_id));
 
         // Event consumer has no caller to return to; log a failed write.
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed after conversation started: {e}");
         }
     });
@@ -475,7 +537,7 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8]) {
         });
         crate::emit_message_received(convo_id, &text, ts as i64);
 
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed after inbound message: {e}");
         }
     });

--- a/rust-lib/src/delivery.rs
+++ b/rust-lib/src/delivery.rs
@@ -1,6 +1,12 @@
-//! `DeliveryService` impl that forwards `publish()` to delivery_module.
+//! `Transport` impl bridging the client's delivery boundary to delivery_module.
+//!
+//! `publish` forwards each outbound envelope to delivery_module; `subscribe`
+//! queues the core's interest in a delivery address (forwarded once the node is
+//! started, see `inbound.rs`); `inbound` hands the client the channel the module
+//! feeds with received payloads.
 
-use client::{AddressedEnvelope, DeliveryService};
+use crossbeam_channel::{Receiver, Sender};
+use logos_chat::{AddressedEnvelope, DeliveryService, Transport};
 
 /// The single home for chat's content-topic scheme. Both the outbound topic
 /// ([`content_topic_for`]) and the inbound prefix filter (`inbound.rs`) derive
@@ -11,9 +17,26 @@ pub(crate) fn content_topic_for(delivery_address: &str) -> String {
     format!("{TOPIC_PREFIX}{delivery_address}/proto")
 }
 
-/// Stateless delivery service; forwards each publish to delivery_module
-/// through the typed dependency client (cheap to instantiate per call).
-pub(crate) struct SdkDelivery;
+/// Carries each direction of the client's delivery boundary: outbound publishing
+/// and subscription forwarding to delivery_module, plus the inbound payload
+/// stream the client's worker drains.
+#[derive(Debug)]
+pub(crate) struct SdkDelivery {
+    /// Handed to the client once via [`Transport::inbound`]. The module feeds the
+    /// matching sender from delivery_module's `messageReceived` events.
+    inbound_rx: Option<Receiver<Vec<u8>>>,
+    /// Subscription requests from the core, drained by the inbound worker.
+    subscribe_tx: Sender<String>,
+}
+
+impl SdkDelivery {
+    pub(crate) fn new(inbound_rx: Receiver<Vec<u8>>, subscribe_tx: Sender<String>) -> Self {
+        Self {
+            inbound_rx: Some(inbound_rx),
+            subscribe_tx,
+        }
+    }
+}
 
 impl DeliveryService for SdkDelivery {
     type Error = String;
@@ -34,5 +57,22 @@ impl DeliveryService for SdkDelivery {
                 }
             });
         Ok(())
+    }
+
+    fn subscribe(&mut self, delivery_address: &str) -> Result<(), String> {
+        // The core subscribes its inbound addresses at construction, before the
+        // delivery node exists. Queue the topic; the inbound worker forwards it to
+        // delivery_module once the node is started (see `inbound::forward_subscriptions`).
+        self.subscribe_tx
+            .send(content_topic_for(delivery_address))
+            .map_err(|e| e.to_string())
+    }
+}
+
+impl Transport for SdkDelivery {
+    fn inbound(&mut self) -> Receiver<Vec<u8>> {
+        self.inbound_rx
+            .take()
+            .expect("SdkDelivery::inbound called more than once")
     }
 }

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -1,19 +1,17 @@
-//! Background worker that processes delivery_module's events.
+//! Background workers bridging delivery_module and the libchat client.
 //!
-//! Two events drive the worker:
-//! * `messageReceived` — inbound envelopes; decode the payload bytes and
-//!   pass to `ChatClient::receive`.
-//! * `connectionStateChanged` — drives local `delivery_state` so consumers
-//!   don't have to poll delivery_module.
+//! Two workers run alongside the client's own inbound worker:
+//! * The bridge ([`run_bridge`]) drains delivery_module's events: `messageReceived`
+//!   payloads are pushed to the client's inbound channel; `connectionStateChanged`
+//!   drives local `delivery_state`; and the core's queued subscription requests are
+//!   forwarded to delivery_module once its node is started.
+//! * The event consumer ([`run_events`]) drains the client's `Event` stream and
+//!   records each observation in the display history, emitting the matching plugin
+//!   events.
 //!
-//! `messageReceived` triggers a libchat decryption + sqlcipher write that
-//! is too long to run on the Qt main thread; the worker takes it off-thread.
-//!
-//! Subscription is set up in `init` (before the node starts, so the
-//! `connectionStateChanged` emitted during start isn't missed) and the
-//! resulting `EventSubscription`s are moved into the worker — each owns its lp
-//! subscription and a share of the client, keeping events flowing after the
-//! proxy is dropped.
+//! The delivery_module subscriptions are set up in `init` (before the node starts,
+//! so the `connectionStateChanged` emitted during start isn't missed) and the
+//! resulting `EventSubscription`s are moved into the bridge.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{RecvTimeoutError, TryRecvError};
@@ -21,28 +19,45 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crossbeam_channel::{Receiver, Sender};
+use logos_chat::Event;
 use logos_rust_sdk::{EventData, EventSubscription};
 
-use crate::actions::{process_payload, set_delivery_state};
-use crate::module::{with_display_mut, DeliveryStateKind};
+use crate::actions::{record_conversation_started, record_message_received, set_delivery_state};
+use crate::module::{with_display, with_display_mut, DeliveryStateKind};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-pub(crate) fn spawn(
+pub(crate) fn spawn_bridge(
     stop: Arc<AtomicBool>,
     messages: EventSubscription,
     conn: Option<EventSubscription>,
+    inbound_tx: Sender<Vec<u8>>,
+    subscribe_rx: Receiver<String>,
 ) -> JoinHandle<()> {
     thread::Builder::new()
-        .name("rust-chat-inbound".into())
-        .spawn(move || run(stop, messages, conn))
-        .expect("failed to spawn inbound thread")
+        .name("rust-chat-bridge".into())
+        .spawn(move || run_bridge(stop, messages, conn, inbound_tx, subscribe_rx))
+        .expect("failed to spawn bridge thread")
 }
 
-fn run(stop: Arc<AtomicBool>, messages: EventSubscription, mut conn: Option<EventSubscription>) {
+pub(crate) fn spawn_events(events: Receiver<Event>) -> JoinHandle<()> {
+    thread::Builder::new()
+        .name("rust-chat-events".into())
+        .spawn(move || run_events(events))
+        .expect("failed to spawn events thread")
+}
+
+fn run_bridge(
+    stop: Arc<AtomicBool>,
+    messages: EventSubscription,
+    mut conn: Option<EventSubscription>,
+    inbound_tx: Sender<Vec<u8>>,
+    subscribe_rx: Receiver<String>,
+) {
     while !stop.load(Ordering::Relaxed) {
         match messages.receiver().recv_timeout(POLL_INTERVAL) {
-            Ok(evt) => handle_message_received(&evt),
+            Ok(evt) => forward_message(&evt, &inbound_tx),
             Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => return,
         }
@@ -70,23 +85,69 @@ fn run(stop: Arc<AtomicBool>, messages: EventSubscription, mut conn: Option<Even
         if disconnected {
             conn = None;
         }
+
+        forward_subscriptions(&subscribe_rx);
     }
 }
 
-fn handle_message_received(evt: &EventData) {
+/// Decode a `messageReceived` event and push its payload to the client's inbound
+/// channel. The loose topic-prefix filter stays: libp2p delivers every message in
+/// the shard regardless of subscribed topic, so non-chat traffic is dropped here
+/// and `Core::handle_payload` (inside the client) discriminates the rest.
+fn forward_message(evt: &EventData, inbound_tx: &Sender<Vec<u8>>) {
     let Some(msg) = crate::delivery_module::DeliveryModuleClient::decode_message_received(evt)
     else {
         eprintln!("chat_module inbound: messageReceived payload missing or malformed");
         return;
     };
-    // libp2p delivers every message in the shard regardless of subscribed
-    // topic, so filter loosely on the chat topic prefix and let
-    // `ChatClient::receive` discriminate.
     if !msg.content_topic.starts_with(crate::delivery::TOPIC_PREFIX) {
         return;
     }
+    // The receiver is the client's worker; if it has gone away the client is being
+    // dropped and the bridge is about to stop, so a failed send is benign.
+    let _ = inbound_tx.send(msg.payload);
+}
 
-    process_payload(&msg.payload);
+/// Forward the core's queued subscription requests to delivery_module, but only
+/// once its node is online. `subscribe` rejects until the node is started, so the
+/// requests queued at client construction wait in the channel until then; later
+/// requests are forwarded as they arrive.
+fn forward_subscriptions(subscribe_rx: &Receiver<String>) {
+    if with_display(|d| d.delivery_state.state) != DeliveryStateKind::Online {
+        return;
+    }
+    while let Ok(topic) = subscribe_rx.try_recv() {
+        crate::modules()
+            .delivery_module
+            .subscribe_async(&topic, move |res| {
+                if let Err(e) = res {
+                    eprintln!("chat_module: delivery_module.subscribe failed: {e}");
+                }
+            });
+    }
+}
+
+/// Drain the client's event stream until the client is dropped (the sender
+/// disconnects and the iterator ends). Each event is recorded in the display
+/// history, which re-emits it to consumers over IPC.
+fn run_events(events: Receiver<Event>) {
+    for event in events {
+        match event {
+            Event::ConversationStarted { convo_id, .. } => {
+                record_conversation_started(&convo_id);
+            }
+            Event::MessageReceived {
+                convo_id, content, ..
+            } => {
+                record_message_received(&convo_id, &content);
+            }
+            Event::InboundError { message } => {
+                eprintln!("chat_module: inbound error: {message}");
+            }
+            // `Event` is `#[non_exhaustive]`; ignore variants added upstream.
+            _ => {}
+        }
+    }
 }
 
 fn handle_connection_state(status: &str) {
@@ -102,9 +163,9 @@ fn handle_connection_state(status: &str) {
 /// The delivery state to move to for an upstream connectivity `status`, or
 /// `None` to ignore the event. While still `Initialising`, connectivity is
 /// ignored: delivery reports `Connected` mid-bootstrap, ~tens of seconds before
-/// the transport can service a call, so readiness is gated on the start/subscribe
-/// handshake (see `actions::initialize`) — not on this event. Once started,
-/// connectivity drives online/offline for reconnect handling.
+/// the transport can service a call, so readiness is gated on the start
+/// handshake (see `actions::start_delivery_bootstrap`) — not on this event. Once
+/// started, connectivity drives online/offline for reconnect handling.
 pub(crate) fn connection_transition(
     current: DeliveryStateKind,
     status: &str,
@@ -156,7 +217,7 @@ mod tests {
     #[test]
     fn connectivity_ignored_until_started() {
         // Pre-startup, `Connected` fires mid-bootstrap and must NOT promote to
-        // Online — readiness is gated on the start/subscribe handshake.
+        // Online — readiness is gated on the start handshake.
         assert_eq!(
             connection_transition(DeliveryStateKind::Initialising, "Connected"),
             None

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -19,9 +19,10 @@
 //!
 //! Return conventions. Status-bearing methods return `result`, surfaced here as
 //! `Result<serde_json::Value, String>`: `Ok(value)` carries any payload (a
-//! conversation id, an intro bundle, or `Null`), `Err(message)` a human-readable
-//! reason. Collection getters return `serde_json::Value` (a JSON array/object);
-//! `get_installation_name` returns a plain string, empty when not initialised.
+//! conversation id or `Null`), `Err(message)` a human-readable reason.
+//! Collection getters return `serde_json::Value` (a JSON array/object);
+//! `get_installation_name`/`get_address` return a plain string, empty when not
+//! initialised.
 //!
 //! Events reach consumers over the lp_* IPC channel: the operations below call
 //! the generated `emit_*` functions (see the included scaffold), which the host
@@ -127,18 +128,12 @@ impl ChatModule for ChatModuleImpl {
             .map_err(|e| e.to_string())
     }
 
-    fn create_intro_bundle(&mut self) -> Result<Value, String> {
-        actions::create_intro_bundle()
-            .map(Value::String)
-            .map_err(|e| e.to_string())
+    fn get_address(&mut self) -> String {
+        actions::get_address()
     }
 
-    fn create_conversation(
-        &mut self,
-        peer_intro_bundle: String,
-        initial_content: String,
-    ) -> Result<Value, String> {
-        actions::create_conversation(&peer_intro_bundle, &initial_content)
+    fn create_conversation(&mut self, peer_address: String) -> Result<Value, String> {
+        actions::create_conversation(&peer_address)
             .map(Value::String)
             .map_err(|e| e.to_string())
     }

--- a/rust-lib/src/module.rs
+++ b/rust-lib/src/module.rs
@@ -2,18 +2,21 @@
 //!
 //! State is split across two independent locks so the fast read methods never
 //! wait on slow libchat work:
-//! * [`ModuleHandle`] (the [`module`] singleton) guards the `!Send` `ChatClient`
-//!   and the worker handle — held across libchat crypto (create/send on the
-//!   dispatch thread, receive on the worker). `unsafe impl Send` is sound
-//!   because every access is serialised through this mutex.
+//! * [`ModuleHandle`] (the [`module`] singleton) guards the [`Client`] and the
+//!   background worker handles. The outbound calls (create/send) take this lock
+//!   for the libchat crypto; they run on the dispatch thread and return without
+//!   blocking on the network (publish is async).
 //! * [`with_display`]/[`with_display_mut`] guard the display history
 //!   ([`Display`]): the conversation log, delivery state, and cached identity
 //!   name. The read methods (`get_messages`/`list_conversations`/`status`/
 //!   `get_installation_name`) lock only this, so they return promptly even while
-//!   the client lock is held for a long decrypt or send.
+//!   the client lock is held for a long send.
 //!
 //! A mutation locks the client (for the libchat call) then the display (to
 //! record the result) — never the reverse — so the two locks can't deadlock.
+//! Inbound decryption runs inside the client's own worker; the event consumer
+//! takes only the display lock to record the result, so it never waits on the
+//! client lock either.
 
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -21,11 +24,18 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use client::ChatClient;
+use libchat::ChatStorage;
+use logos_chat::{ChatClient, DelegateSigner, EphemeralRegistry};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
 use crate::persistence::AppState;
+
+/// The chat client as this module configures it: a random delegate identity, the
+/// delivery_module-backed [`SdkDelivery`] transport, an in-process registry (only
+/// the intro-bundle path is used, which needs no shared registry), and a
+/// SQLCipher-backed store.
+pub(crate) type Client = ChatClient<DelegateSigner, SdkDelivery, EphemeralRegistry, ChatStorage>;
 
 // ── Delivery state ──────────────────────────────────────────────────────────
 
@@ -83,21 +93,18 @@ impl DeliveryState {
 // ── ModuleState (client lock) ──────────────────────────────────────────────────
 
 pub(crate) struct ModuleState {
-    pub client: ChatClient<SdkDelivery>,
-    /// Signal flag for the inbound worker. The worker observes this between
+    pub client: Client,
+    /// Signal flag for the inbound bridge worker. The worker observes this between
     /// poll iterations so shutdown() bounds wait time at one poll period.
     pub inbound_stop: Arc<AtomicBool>,
-    /// Inbound worker handle. `Option` so `shutdown()` can `take()` it before
-    /// `join`-ing while still under the module mutex.
+    /// Inbound bridge worker handle (delivery_module events → client, connection
+    /// state, subscription forwarding). `Option` so `shutdown()` can `take()` it
+    /// before `join`-ing while still under the module mutex.
     pub inbound_thread: Option<JoinHandle<()>>,
+    /// Event consumer worker handle. Drains the client's `Receiver<Event>`; it
+    /// exits once the client is dropped and the event sender disconnects.
+    pub event_thread: Option<JoinHandle<()>>,
 }
-
-// `ChatClient` holds `Rc<…>` so `ModuleState` isn't `Send` by auto-derive.
-// Sound because every access goes through `ModuleHandle` under the mutex,
-// which both serialises Rc refcount updates and provides the happens-before
-// barrier the non-atomic refcount needs. `Mutex<T>: Sync` falls out from
-// `T: Send`, so we assert `Send` only.
-unsafe impl Send for ModuleState {}
 
 /// Unreachable under `panic = "abort"` — the process dies before a
 /// poisoning panic can return.

--- a/rust-lib/src/module.rs
+++ b/rust-lib/src/module.rs
@@ -25,17 +25,25 @@ use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use libchat::ChatStorage;
-use logos_chat::{ChatClient, DelegateSigner, EphemeralRegistry};
+use logos_chat::{ChatClient, HttpRegistry};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
 use crate::persistence::AppState;
 
-/// The chat client as this module configures it: a random delegate identity, the
-/// delivery_module-backed [`SdkDelivery`] transport, an in-process registry (only
-/// the intro-bundle path is used, which needs no shared registry), and a
-/// SQLCipher-backed store.
-pub(crate) type Client = ChatClient<DelegateSigner, SdkDelivery, EphemeralRegistry, ChatStorage>;
+/// The chat client as this module configures it: a delegate identity associated
+/// with an ephemeral account, the delivery_module-backed [`SdkDelivery`]
+/// transport, the devnet HTTP registry, and an in-memory store. Chats are
+/// ephemeral (see [`PERSISTENCE_ENABLED`]).
+pub(crate) type Client = ChatClient<SdkDelivery, HttpRegistry, ChatStorage>;
+
+/// Whether chat state persists across restarts. Off: identity, MLS/crypto state,
+/// and the display history are all ephemeral. DirectV1 has no reload path in
+/// libchat yet (a DirectV1 conversation's MLS state is never reloaded), so
+/// persisting would strand crypto state a restart can't resume. The persistence
+/// code (SQLCipher store, `history.json`) is kept behind this switch; flip it on
+/// once libchat can reload DirectV1 state.
+pub(crate) const PERSISTENCE_ENABLED: bool = false;
 
 // ── Delivery state ──────────────────────────────────────────────────────────
 
@@ -178,6 +186,10 @@ pub(crate) struct Display {
     /// libchat's intrinsic installation name, cached so `get_installation_name`
     /// needn't touch the client (which is behind the other lock).
     pub intrinsic_name: String,
+    /// The local installation address (libchat `ChatClient::addr`), cached so
+    /// `get_address` needn't touch the client. A peer needs this value to open a
+    /// DirectV1 conversation with this installation.
+    pub address: String,
 }
 
 impl Default for Display {
@@ -187,6 +199,7 @@ impl Default for Display {
             state_path: PathBuf::new(),
             delivery_state: DeliveryState::stopped(),
             intrinsic_name: String::new(),
+            address: String::new(),
         }
     }
 }

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -59,7 +59,7 @@ pub(crate) struct DisplayMessage {
 /// Per-conversation state held alongside libchat's cryptographic state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ChatSession {
-    /// libchat conversation ID (`ConversationIdOwned` rendered to string).
+    /// libchat conversation ID.
     pub chat_id: String,
     /// User-set display label. `None` falls back to `module::short_label`.
     pub nickname: Option<String>,


### PR DESCRIPTION
## feat: bump libchat to origin/main; migrate to threaded client

libchat replaced the synchronous ChatClient::receive with a threaded
client (package renamed client -> logos-chat): an inbound worker drives
Core::handle_payload and surfaces results as Events on a channel, and
DeliveryService gained a subscribe(addr) the core drives itself.

- SdkDelivery becomes a Transport: publish forwards to delivery_module,
  subscribe queues the core's inbound addresses, inbound hands the
  client the payload channel the bridge worker feeds.
- Split the receive worker in two: a bridge (delivery_module events ->
  inbound channel, connection state, subscription forwarding) and an
  event consumer recording history; ChatClient is Send, so drop the
  unsafe impl Send for ModuleState.
- Build via ChatClientBuilder with a fallibly-built SQLCipher store
  (the builder's storage_config panics on a bad DB).
- Toolchain: rust 1.95.0 and protobuf in the module build (libchat's
  closure raises the MSRV and runs prost-build); CI's bare-cargo steps
  run via nix develop for protoc.

Known limitation at this commit: the threaded client drops PrivateV1
message content at the receiver (empty sender credential), so the
two-instance doc-test cannot pass; resolved by the DirectV1 migration.

## feat: migrate from PrivateV1 to account-addressed DirectV1

Peers share one account address: the account publishes a signed device
bundle to the registry, the initiator resolves it to the delegate's key
package, and the Welcome routes to the signer-scoped inbox. No intro
bundles, no out-of-band exchange; restores the message round-trip the
threaded-client bump broke.

- initialize mints a TestLogosAccount and a pure DelegateSigner,
  publishes the bundle via account.add_delegate_signer, and builds with
  ChatClientBuilder::new(account address); get_address returns the
  account address (what client.addr() returns too).
- API: create_intro_bundle + create_conversation(bundle, content) are
  replaced by get_address + create_conversation(peer_address).
- Persistence disabled (ephemeral chats): DirectV1 has no reload path
  in libchat yet; the SQLCipher and history code stays behind the
  switch.
- doctest: the two-instance exchange opens the conversation by address.

---

Note: the two commits stay together in one PR because the first cannot ship
alone. The threaded-client bump drops PrivateV1 message content at the
receiver, breaking 1:1 chats; the DirectV1 migration restores the round-trip.
They are kept as separate atomic commits for review.
