### PR TITLE
ci: switch Nix binary cache from Cachix to Attic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
 
 jobs:
   lint:
     name: Lint
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -25,14 +27,29 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
+      - uses: cachix/cachix-action@v15
+        with:
+          name: logos-co
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Fork PRs
+      # get no secrets, and an empty endpoint fails `attic use`.
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        if: github.event.pull_request.head.repo.fork != true
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
@@ -60,6 +77,7 @@ jobs:
 
   cargo:
     name: cargo (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,14 +92,29 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
+      - uses: cachix/cachix-action@v15
+        with:
+          name: logos-co
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Fork PRs
+      # get no secrets, and an empty endpoint fails `attic use`.
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        if: github.event.pull_request.head.repo.fork != true
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
@@ -102,6 +135,7 @@ jobs:
 
   nix:
     name: nix (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -116,14 +150,29 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
+      - uses: cachix/cachix-action@v15
+        with:
+          name: logos-co
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Fork PRs
+      # get no secrets, and an empty endpoint fails `attic use`.
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        if: github.event.pull_request.head.repo.fork != true
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       - name: nix build .#chat_module
         run: nix build .#chat_module -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
@@ -72,10 +75,13 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
@@ -111,10 +117,13 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       - name: nix build .#chat_module
         run: nix build .#chat_module -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
             extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
 
-      # Read-only, and the sole source for a large part of the Rust crate
-      # closure. Drop it once a run shows Attic serving those paths.
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          skipPush: true
-
       # Publishing only; both caches are public to read, which the substituter
       # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
       # environment, so only the master jobs that opt into it reach the public
@@ -96,13 +89,6 @@ jobs:
             extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
 
-      # Read-only, and the sole source for a large part of the Rust crate
-      # closure. Drop it once a run shows Attic serving those paths.
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          skipPush: true
-
       # Publishing only; both caches are public to read, which the substituter
       # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
       # environment, so only the master jobs that opt into it reach the public
@@ -153,13 +139,6 @@ jobs:
             extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
             extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
-
-      # Read-only, and the sole source for a large part of the Rust crate
-      # closure. Drop it once a run shows Attic serving those paths.
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          skipPush: true
 
       # Publishing only; both caches are public to read, which the substituter
       # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -47,13 +47,6 @@ jobs:
             extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
             fallback = true
 
-      # Read-only, and the sole source for a large part of the Rust crate
-      # closure. Drop it once a run shows Attic serving those paths.
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          skipPush: true
-
       # Publishing only; both caches are public to read, which the substituter
       # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
       # environment, so only the master jobs that opt into it reach the public

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -25,9 +25,13 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+
 jobs:
   doctests:
     name: doc-tests (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -39,14 +43,29 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public https://cache.nix.logos.co/ci
+            extra-trusted-public-keys = public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU= ci:aVJqjS4NWX5WfqHO0AEhIScjGu/JyK5FoydPrnEbMvc=
+            fallback = true
 
+      # Read-only, and the sole source for a large part of the Rust crate
+      # closure. Drop it once a run shows Attic serving those paths.
+      - uses: cachix/cachix-action@v15
+        with:
+          name: logos-co
+          skipPush: true
+
+      # Publishing only; both caches are public to read, which the substituter
+      # above already covers. ATTIC_TOKEN_PUBLIC lives in the public-cache
+      # environment, so only the master jobs that opt into it reach the public
+      # cache; every other ref pushes to ci with the repo-wide token. Fork PRs
+      # get no secrets, and an empty endpoint fails `attic use`.
       - name: Setup Attic cache
-        uses: ryanccn/attic-action@v0
+        if: github.event.pull_request.head.repo.fork != true
+        uses: ryanccn/attic-action@v0.4.1
         with:
           endpoint: ${{ secrets.ATTIC_ENDPOINT }}
-          cache: public
-          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
-          skip-push: ${{ github.event_name == 'pull_request' }}
+          cache: ${{ env.ATTIC_CACHE }}
+          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
 
       # Resolve the commit under test. For pull requests this is the PR's head
       # commit (not the synthetic merge commit); for pushes it's the pushed commit.
@@ -71,8 +90,9 @@ jobs:
       # Pre-build the closures the spec builds inline, so its bash steps hit the
       # nix store instead of compiling under the run (and inside its poll budgets).
       # chat_module#lgx (libchat + openssl from source) is the heavy, uncached one
-      # (it's the commit under test); logoscore / delivery / lgpm should be attic
-      # hits. Fork PRs blank the SHA -> build the default branch, as the spec does.
+      # (it's the commit under test); logoscore / delivery / lgpm turn into cache
+      # hits once a run has populated Attic with them.
+      # Fork PRs blank the SHA -> build the default branch, as the spec does.
       - name: Pre-build doc-test closures
         shell: bash
         run: |

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -40,10 +40,13 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v15
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: public
+          token: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+          skip-push: ${{ github.event_name == 'pull_request' }}
 
       # Resolve the commit under test. For pull requests this is the PR's head
       # commit (not the synthetic merge commit); for pushes it's the pushed commit.
@@ -68,7 +71,7 @@ jobs:
       # Pre-build the closures the spec builds inline, so its bash steps hit the
       # nix store instead of compiling under the run (and inside its poll budgets).
       # chat_module#lgx (libchat + openssl from source) is the heavy, uncached one
-      # (it's the commit under test); logoscore / delivery / lgpm should be cachix
+      # (it's the commit under test); logoscore / delivery / lgpm should be attic
       # hits. Fork PRs blank the SHA -> build the default branch, as the spec does.
       - name: Pre-build doc-test closures
         shell: bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "Logos Chat Module";
 
+  # Pull pre-built artifacts (delivery module, liblogosdelivery, …) from the
+  # self-hosted Logos Attic cache, for local builds too — CI configures its
+  # substituters itself. Read-only and public; see infra-ci#263. Only the
+  # public (master-built) cache belongs here; ci is CI-only by design.
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
+  };
+
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
 


### PR DESCRIPTION
### ci: switch Nix binary cache from Cachix to Attic

Replace cachix/cachix-action with ryanccn/attic-action (public cache, cache.nix.logos.co) across ci.yml and doctests.yml, per infra-ci #263. PRs read-only via skip-push; master/main builds populate the cache.

### ci: let PR builds populate the Attic ci cache

Only master builds populated a cache, so every PR run rebuilt the delivery closure from source. The Attic setup carries a separate ci cache for exactly this, reachable with the repo-wide ATTIC_TOKEN_CI, while ATTIC_TOKEN_PUBLIC stays scoped to the public-cache environment that only master jobs enter.

Reading is separate from publishing. Both caches are public, so the substituter belongs in the Nix install where it needs no credentials, which keeps fork PRs and any other run without secrets on the fast path; only the push step is gated.

Cachix stays on as a read-only substituter. Attic's public cache was recreated during the signing-key rotation and serves almost none of the Rust crate closure today, where Cachix is still the only source for roughly 40% of the paths a run fetches. Drop it once a run shows Attic serving them.

---

Measured on the first pushed round: the `ci` cache went from 1 to 24 of a fixed 60-path sample, and Doc-Tests fell from its 27 to 37 minute baseline to 22m35s, with its second build wave dropping from 56 built derivations to 14 and 41 paths served from `ci`. Cachix served 871 paths in the same CI run, which is why it stays on for now.
