### PR TITLE
chore(deps): pin logos-delivery-module to v0.1.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1075,17 +1075,17 @@
         "nix-bundle-lgx": "nix-bundle-lgx_10"
       },
       "locked": {
-        "lastModified": 1781019490,
-        "narHash": "sha256-TQXLZMbK4pW9vfaq6RNNUYzm0gX4DjxhtywavFyo5Wc=",
+        "lastModified": 1782251051,
+        "narHash": "sha256-ggpO1f8ANSE2swemWtmbQeSpj7Nuq2Y51+GnlhsR25s=",
         "owner": "logos-co",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
+        "rev": "794c21cbe177bdea16d4907468eaf52d4282dda7",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "v0.1.3",
         "repo": "logos-delivery-module",
-        "rev": "2577383f6e0de24793b523d6ea4991aa6339afd8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,9 @@
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
 
-    # Pinned to the commit (post-v0.1.2) carrying the zerokit/RLN nix build fix
-    # (delivery-module #49). Kept in lockstep with logos-chat-ui's pin. Not yet
-    # tagged — re-pin to the release tag once one is cut.
-    logos-delivery-module.url = "github:logos-co/logos-delivery-module/2577383f6e0de24793b523d6ea4991aa6339afd8";
+    # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix
+    # build fix (delivery-module #49). Kept in lockstep with logos-chat-ui's pin.
+    logos-delivery-module.url = "github:logos-co/logos-delivery-module/v0.1.3";
   };
 
   outputs = inputs@{ self, logos-module-builder, logos-delivery-module, ... }:


### PR DESCRIPTION
Re-pins the `logos-delivery-module` flake input from raw commit `2577383` to the `v0.1.3` release tag and regenerates `flake.lock` (now at `794c21c`, the tag's commit — 4 commits forward, none dropped).

The old pin was a stopgap for the zerokit/RLN nix build fix (logos-co/logos-delivery-module#49) before it was tagged; its comment said to re-pin once a release was cut. v0.1.3 (2026-06-23) is that release.

Note: the pin is kept in lockstep with logos-chat-ui, which will need the same bump separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)