### PR TITLE
chore: bump module version to 0.1.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_module",
   "display_name": "Chat Module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Chat module for Logos",
   "author": "Logos Core Team",
   "type": "core",


### PR DESCRIPTION
Bumps `metadata.json` `version` to 0.1.2 — missed in #41, and the drafted v0.1.2 release already assumes it.

The draft release targets `master`, so publishing after this merges will cut the `v0.1.2` tag from the corrected head; no release repointing needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)