### PR TITLE
feat: expose conversation kind and group roster (contract 0.3.0)

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -1,15 +1,16 @@
 name: Doc-Tests
 
-# Runs chat_module's usage doc-test via the shared doctest CLI, against the commit
-# under test. The spec is an executable tutorial that builds this module's `.lgx`,
-# loads it into two headless `logoscore` daemons, and drives a real two-party
-# message round-trip over the live delivery network. Because it exercises the
-# module end to end, the job also serves as an integration check and fails if the
-# round-trip does not complete.
+# Runs chat_module's usage doc-tests via the shared doctest CLI, against the
+# commit under test. Each spec is an executable tutorial that builds this
+# module's `.lgx`, loads it into headless `logoscore` daemons, and drives a real
+# exchange over the live delivery network: the two-instance 1:1 round-trip and
+# the three-instance GroupV2 conversation. Because they exercise the module end
+# to end, the job also serves as an integration check and fails if an exchange
+# does not complete.
 #
-# Linux-only: it runs two real delivery instances on one host (distinct data dirs
-# and delivery ports). The exchange needs outbound network to reach the logos.test
-# Waku fleet, which GitHub-hosted runners have.
+# Linux-only: it runs several real delivery instances on one host (distinct data
+# dirs and delivery ports). The exchanges need outbound network to reach the
+# logos.test Waku fleet, which GitHub-hosted runners have.
 
 on:
   pull_request:
@@ -84,10 +85,11 @@ jobs:
       # test, so `github:logos-co/logos-chat-module{release}#lgx` in the spec builds
       # this PR/push. --continue-on-fail so the run walks every step and the report
       # is complete; the job still exits non-zero if any step failed.
-      - name: Run doc-test
+      - name: Run doc-tests
         run: |
           nix run github:logos-co/logos-doctest -- run \
             doctests/chat-module-exchange.test.yaml \
+            doctests/chat-module-group.test.yaml \
             --verbose \
             --continue-on-fail \
             --release-for logos-chat-module=${{ steps.commit.outputs.sha }} \
@@ -114,12 +116,14 @@ jobs:
 
       - name: Verify markdown generation
         run: |
-          out="${{ runner.temp }}/chat-module-exchange.md"
-          nix run github:logos-co/logos-doctest -- generate \
-            doctests/chat-module-exchange.test.yaml \
-            --release-for logos-chat-module=${{ steps.commit.outputs.sha }} \
-            -o "$out"
-          test -s "$out"
+          for spec in chat-module-exchange chat-module-group; do
+            out="${{ runner.temp }}/${spec}.md"
+            nix run github:logos-co/logos-doctest -- generate \
+              "doctests/${spec}.test.yaml" \
+              --release-for logos-chat-module=${{ steps.commit.outputs.sha }} \
+              -o "$out"
+            test -s "$out"
+          done
           echo "Generated markdown successfully"
 
   publish-report:
@@ -190,9 +194,10 @@ jobs:
             const body =
               `${marker}\n` +
               `### Doc-test report\n\n` +
-              `Two headless \`chat_module\` instances built against this commit, ` +
-              `driven through the full message round-trip, rendered alongside the ` +
-              `commands actually run and their output ` +
+              `Headless \`chat_module\` instances built against this commit, ` +
+              `driven through the 1:1 round-trip and the three-instance group ` +
+              `conversation, rendered alongside the commands actually run and ` +
+              `their output ` +
               `(updated each run, commit \`${context.sha.slice(0,7)}\`):\n\n` +
               `- [Execution report](${url})\n\n` +
               `_Pages can take a minute to update after the run finishes._`;

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ conversation id, an intro bundle, or null), `Err(message)` a human-readable
 reason. Collection getters (`list_conversations`, `get_messages`) return JSON
 arrays. See the `.lidl` for the full method list and record shapes.
 
+Two conversation shapes are exposed. `create_conversation(peer_address)` opens
+a 1:1 DirectV1 conversation. `create_group_conversation()` creates a GroupV2
+(de-mls) group with this installation as its only member, grown one peer at a
+time with `add_group_member(convo_id, peer_address)`; every member sees the
+same conversation id, and adds are committed by the group's steward
+asynchronously, so a peer joins some time after the call returns. Received
+messages carry a `sender` (on the `Message` record and the `message_received`
+event): the sender's directory-verified account address, or its device id
+when the sender claims no account.
+
 ## Events
 
 The module pushes six events over the lp_* IPC event channel (LIDL `event`
@@ -56,7 +66,7 @@ declarations); consumers subscribe via `on_<event>()` — no polling. Each carri
 positional arguments in `.lidl` order:
 
 - **`message_received`** — an inbound message was decrypted
-  - `convo_id` (`tstr`), `content` (`tstr`), `timestamp_ms` (`int`)
+  - `convo_id` (`tstr`), `content` (`tstr`), `timestamp_ms` (`int`), `sender` (`tstr`)
 - **`message_sent`** — an outbound message was recorded
   - `convo_id` (`tstr`), `content` (`tstr`), `timestamp_ms` (`int`)
 - **`conversation_created`** — a conversation was opened
@@ -80,16 +90,21 @@ readiness arrives later as a `delivery_state_changed` event reaching `online`.
 
 ## Doc-tests
 
-[`doctests/chat-module-exchange.test.yaml`](doctests/chat-module-exchange.test.yaml)
-is an executable usage tutorial: it loads `chat_module` into two headless
-[`logoscore`](https://github.com/logos-co/logos-logoscore-cli) daemons and drives
-a real, end-to-end-encrypted message round-trip between them over the live
-delivery network, documenting the module's API by example. It runs on every PR
-via [`.github/workflows/doctests.yml`](.github/workflows/doctests.yml) (the
-[shared doctest CLI](https://github.com/logos-co/logos-doctest) builds the commit
-under test), which also makes it an integration check. Run it locally against
-latest master (add `--release-for logos-chat-module=<branch-or-sha>` to pin it to
-a pushed commit instead):
+The specs under [`doctests/`](doctests/) are executable usage tutorials: each
+loads `chat_module` into headless
+[`logoscore`](https://github.com/logos-co/logos-logoscore-cli) daemons and
+drives a real, end-to-end-encrypted exchange between them over the live
+delivery network, documenting the module's API by example.
+[`chat-module-exchange.test.yaml`](doctests/chat-module-exchange.test.yaml) is
+the two-instance 1:1 round-trip;
+[`chat-module-group.test.yaml`](doctests/chat-module-group.test.yaml) runs a
+three-instance GroupV2 conversation (create, grow member by member, fan-out
+messages with sender attribution). They run on every PR via
+[`.github/workflows/doctests.yml`](.github/workflows/doctests.yml) (the
+[shared doctest CLI](https://github.com/logos-co/logos-doctest) builds the
+commit under test), which also makes them an integration check. Run one locally
+against latest master (add `--release-for logos-chat-module=<branch-or-sha>` to
+pin it to a pushed commit instead):
 
 ```bash
 nix run github:logos-co/logos-doctest -- run doctests/chat-module-exchange.test.yaml

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ a 1:1 DirectV1 conversation. `create_group_conversation()` creates a GroupV2
 (de-mls) group with this installation as its only member, grown one peer at a
 time with `add_group_member(convo_id, peer_address)`; every member sees the
 same conversation id, and adds are committed by the group's steward
-asynchronously, so a peer joins some time after the call returns. Received
+asynchronously, so a peer joins some time after the call returns.
+`list_group_members(convo_id)` returns a group's roster from libchat's MLS
+state. The `Conversation` record and the `conversation_created` event carry a
+`kind` (`"direct"` or `"group"`) distinguishing the two shapes. Received
 messages carry a `sender` (on the `Message` record and the `message_received`
 event): the sender's directory-verified account address, or its device id
 when the sender claims no account.
@@ -70,7 +73,7 @@ positional arguments in `.lidl` order:
 - **`message_sent`** — an outbound message was recorded
   - `convo_id` (`tstr`), `content` (`tstr`), `timestamp_ms` (`int`)
 - **`conversation_created`** — a conversation was opened
-  - `convo_id` (`tstr`), `is_outgoing` (`bool`), `peer_label` (`tstr`)
+  - `convo_id` (`tstr`), `is_outgoing` (`bool`), `peer_label` (`tstr`), `kind` (`tstr`)
 - **`conversation_updated`** — a conversation's metadata changed
   - `convo_id` (`tstr`)
 - **`conversation_deleted`** — a conversation was removed

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -5,30 +5,31 @@ release: ""
 
 intro: |
   This tutorial shows how to use `chat_module` end to end, by example. A
-  conversation takes two parties: one shares an intro bundle, the other opens a
-  conversation from it with a first message, and a reply flows back. That
+  conversation takes two parties: one shares their address, the other opens a
+  conversation with it, the first side joins, and messages flow both ways. That
   round-trip spans **two** independent `chat_module` instances talking over the
   live delivery network.
 
   So the tutorial runs two headless [`logoscore`](https://github.com/logos-co/logos-logoscore-cli)
   daemons (Alice and Bob), each loading `chat_module` and its runtime dependency
   `delivery_module`, and drives them through the `logoscore call` CLI: `init`,
-  `create_intro_bundle`, `create_conversation`, `send_message`, and reading the
-  thread back with `list_conversations` / `get_messages`.
+  `get_address`, `create_conversation`, `send_message`, and reading the thread
+  back with `list_conversations` / `get_messages`.
 
   `logoscore call` is request/response, so it never receives the module's push
   events; instead each side **polls** its own persisted state (`status`,
   `list_conversations`, `get_messages`) for what an event-driven consumer would
   get as `delivery_state_changed` / `conversation_created` / `message_received`.
-  The exchange itself (X3DH bundle, end-to-end-encrypted messages over
-  `delivery_module`) is exactly what an application drives.
+  The exchange itself (an MLS group keyed from key packages exchanged through a
+  registry, end-to-end-encrypted messages over `delivery_module`) is exactly what
+  an application drives.
 
 what_you_build: "A verified end-to-end, end-to-end-encrypted message round-trip between two headless chat_module instances, with no UI."
 
 what_you_learn:
   - "Run two isolated `logoscore` daemons on one host, selected by `--config-dir`"
   - "Bring a `chat_module` instance online with `init()` and poll `status()` for `delivery_state == online`"
-  - "Drive the full round-trip over the CLI (share a bundle, open a conversation, reply) and observe receipt by polling `list_conversations` / `get_messages` instead of events"
+  - "Drive the full round-trip over the CLI (share an address, open a conversation, reply) and observe receipt by polling `list_conversations` / `get_messages` instead of events"
   - "How the `result`-bearing methods wrap their payload as `{success, value, error}` while the collection/status getters return their value directly"
 
 prerequisites:
@@ -198,49 +199,74 @@ sections:
   - title: "The round-trip"
     step: true
     text: |
-      Alice shares her intro bundle, Bob opens a conversation from it with a first
-      message, Alice sees it and replies, and the reply reaches Bob.
+      Alice shares her address, Bob opens a DirectV1 conversation with her, Alice
+      joins via the invite, then Bob sends the first message and Alice replies — a
+      bidirectional round-trip between two independent headless instances.
     steps:
-      - title: "Alice creates her intro bundle"
+      - title: "Alice publishes her address"
         run: |
-          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_intro_bundle)
-          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "bundle failed: $out" >&2; exit 1; }
-          echo "$out" | jq -j '.result.value' > alice-bundle.txt
-          echo "alice bundle bytes: $(wc -c < alice-bundle.txt)"
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module get_address)
+          echo "$out"
+          echo "$out" | jq -j '.result' > alice-addr.txt
+          echo "alice address: $(cat alice-addr.txt)"
         code_block: |
-          logoscore --config-dir alice call chat_module create_intro_bundle | jq -j '.result.value' > alice-bundle.txt
+          logoscore --config-dir alice call chat_module get_address | jq -j '.result' > alice-addr.txt
         expect_contains:
-          - "alice bundle bytes:"
-        check_file: "alice-bundle.txt"
+          - "alice address:"
+        check_file: "alice-addr.txt"
         post_text: |
-          `create_intro_bundle` returns the LIDL `result` type, so its payload is at
-          `.result.value` (the X3DH prekey bundle a peer needs to start a
-          conversation with Alice), with `.result.success` / `.result.error`
-          alongside.
-      - title: "Bob opens a conversation from the bundle and sends the first message"
+          `get_address` returns the LIDL `tstr` type, so its payload is the string
+          directly at `.result` — Alice's installation address, what a peer needs to
+          open a conversation with her. Her key package was published to the registry
+          during `init`, so the address alone lets Bob reach her.
+      - title: "Bob opens a conversation with Alice"
         run: |
-          out=$(./logos/bin/logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob)
+          out=$(./logos/bin/logoscore --config-dir bob call chat_module create_conversation @alice-addr.txt)
           echo "$out"
           echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "create_conversation failed: $out" >&2; exit 1; }
           echo "$out" | jq -j '.result.value' > bob-convo.txt
           echo "bob convo: $(cat bob-convo.txt)"
         code_block: |
-          logoscore --config-dir bob call chat_module create_conversation @alice-bundle.txt hello-from-bob
+          logoscore --config-dir bob call chat_module create_conversation @alice-addr.txt
         expect_contains:
           - '"status":"ok"'
           - "bob convo:"
         post_text: |
-          `@alice-bundle.txt` feeds the bundle file as the first argument. The
-          returned `result.value` is Bob's **local** conversation id; the first
-          message is published to Alice asynchronously.
-      - title: "Alice receives the conversation and Bob's message"
+          `@alice-addr.txt` feeds Alice's address as the argument. Bob fetches her
+          key package from the registry and sends her an MLS invite; `result.value`
+          is Bob's conversation id. The first message is sent separately, once Alice
+          has joined.
+      - title: "Alice joins the conversation"
         run: |
           for i in $(seq 1 50); do
             cid=$(./logos/bin/logoscore --config-dir alice call chat_module list_conversations 2>/dev/null | jq -r '.result[0].convo_id // empty')
             if [ -n "$cid" ]; then echo "$cid" > alice-convo.txt; echo "ALICE_HAS_CONVO $cid"; break; fi
             sleep 3
           done
-          [ -s alice-convo.txt ] || { echo "alice never received the conversation" >&2; exit 1; }
+          [ -s alice-convo.txt ] || { echo "alice never joined the conversation" >&2; exit 1; }
+        code_block: |
+          # poll until Alice has processed the invite and joined
+          logoscore --config-dir alice call chat_module list_conversations | jq -r '.result[0].convo_id'
+        expect_contains:
+          - "ALICE_HAS_CONVO"
+        post_text: |
+          DirectV1 is group-based, so both sides share one conversation id (the
+          group id) — unlike PrivateV1's asymmetric ids. Once the conversation
+          appears, Alice has joined and subscribed to its delivery address, so she
+          is ready to receive messages on it.
+      - title: "Bob sends the first message"
+        run: |
+          cid=$(cat bob-convo.txt)
+          ./logos/bin/logoscore --config-dir bob call chat_module send_message "$cid" hello-from-bob
+        code_block: |
+          logoscore --config-dir bob call chat_module send_message "$BOB_CONVO" hello-from-bob
+        expect_contains:
+          - '"status":"ok"'
+        post_text: |
+          Bob sends only after Alice has joined (previous step), so the message
+          reaches her subscribed thread rather than racing ahead of her join.
+      - title: "Alice receives Bob's message"
+        run: |
           cid=$(cat alice-convo.txt)
           for i in $(seq 1 50); do
             msgs=$(./logos/bin/logoscore --config-dir alice call chat_module get_messages "$cid" 2>/dev/null || true)
@@ -249,20 +275,14 @@ sections:
           done
           echo "alice never received bob's message" >&2; exit 1
         code_block: |
-          # Alice's local conversation id (X3DH-asymmetric: differs from Bob's)
-          logoscore --config-dir alice call chat_module list_conversations | jq -r '.result[0].convo_id'
-          # poll her thread until Bob's message lands
           logoscore --config-dir alice call chat_module get_messages "$ALICE_CONVO"
         expect_contains:
-          - "ALICE_HAS_CONVO"
           - "ALICE_GOT_BOB_MSG"
         post_text: |
-          Each side has its **own** local conversation id (X3DH gives the initiator
-          and responder different ids for the one logical conversation). Alice reads
-          hers from her own `list_conversations`; received messages are persisted
-          and surface via `get_messages` with no event subscription.
-          `list_conversations` / `get_messages` return their arrays directly under
-          `result`.
+          DirectV1 gives both sides the **same** conversation id (the MLS group id).
+          Received messages are persisted and surface via `get_messages` with no
+          event subscription; `list_conversations` / `get_messages` return their
+          arrays directly under `result`.
       - title: "Alice replies"
         run: |
           cid=$(cat alice-convo.txt)

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -310,7 +310,7 @@ sections:
           for who in alice bob carol; do
             ok=""
             for i in $(seq 1 60); do
-              roster=$(./logos/bin/logoscore --config-dir "$who" call chat_module list_group_members "$gid" 2>/dev/null | jq -r '.result[]?' || true)
+              roster=$(./logos/bin/logoscore --config-dir "$who" call chat_module list_group_members "$gid" 2>/dev/null | jq -r '.result[]?.address' || true)
               if printf '%s\n' "$roster" | grep -qF "$a" && printf '%s\n' "$roster" | grep -qF "$b" && printf '%s\n' "$roster" | grep -qF "$c"; then
                 ok=1; echo "$(echo "$who" | tr a-z A-Z)_ROSTER_COMPLETE"; break
               fi

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -303,6 +303,35 @@ sections:
           logoscore --config-dir carol call chat_module list_conversations
         expect_contains:
           - "CAROL_IN_GROUP"
+      - title: "Every member sees the full three-member roster"
+        run: |
+          gid=$(cat group-id.txt)
+          a=$(cat alice-addr.txt); b=$(cat bob-addr.txt); c=$(cat carol-addr.txt)
+          for who in alice bob carol; do
+            ok=""
+            for i in $(seq 1 60); do
+              roster=$(./logos/bin/logoscore --config-dir "$who" call chat_module list_group_members "$gid" 2>/dev/null | jq -r '.result[]?' || true)
+              if printf '%s\n' "$roster" | grep -qF "$a" && printf '%s\n' "$roster" | grep -qF "$b" && printf '%s\n' "$roster" | grep -qF "$c"; then
+                ok=1; echo "$(echo "$who" | tr a-z A-Z)_ROSTER_COMPLETE"; break
+              fi
+              sleep 4
+            done
+            [ -n "$ok" ] || { echo "$who roster never converged: $roster" >&2; exit 1; }
+          done
+        code_block: |
+          # each member's roster lists all three account addresses
+          logoscore --config-dir alice call chat_module list_group_members "$GROUP_ID"
+          logoscore --config-dir bob   call chat_module list_group_members "$GROUP_ID"
+          logoscore --config-dir carol call chat_module list_group_members "$GROUP_ID"
+        expect_contains:
+          - "ALICE_ROSTER_COMPLETE"
+          - "BOB_ROSTER_COMPLETE"
+          - "CAROL_ROSTER_COMPLETE"
+        post_text: |
+          `list_group_members` reports the group's roster from libchat's MLS
+          state, each member as its directory-verified account address. All
+          three converge on the same three-member set once the adds have
+          committed everywhere.
 
   - title: "Messages fan out to every member, with senders attributed"
     step: true

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -1,0 +1,403 @@
+name: "Headless three-instance group conversation"
+output: chat-module-group.md
+project_name: logos-chat-module
+release: ""
+
+intro: |
+  This tutorial shows `chat_module`'s group API end to end, by example. A
+  GroupV2 conversation starts with its creator as the only member and grows
+  one peer at a time: the creator (or any existing member) invites a peer by
+  address, the group's steward commits the add, and the invited instance joins
+  once the welcome reaches it. Every member sees the **same** conversation id,
+  and each received message carries the sender's directory-verified account
+  address.
+
+  So the tutorial runs three headless [`logoscore`](https://github.com/logos-co/logos-logoscore-cli)
+  daemons (Alice, Bob, and Carol), each loading `chat_module` and its runtime
+  dependency `delivery_module`, and drives them through the `logoscore call`
+  CLI: `init`, `get_address`, `create_group_conversation`, `add_group_member`,
+  `send_message`, and reading the shared thread back with
+  `list_conversations` / `get_messages`.
+
+  Group membership changes are **asynchronous by design**: an add is first
+  agreed by the group (a consensus proposal), then batched into an MLS commit
+  by the group's steward after a commit-inactivity window, and only then does
+  the welcome go out. With the default de-mls timing that window is 60s, so
+  expect a join to land minutes after the `add_group_member` call over the
+  live network — the poll loops below are budgeted for that.
+
+what_you_build: "A verified three-member, end-to-end-encrypted group conversation across three headless chat_module instances, grown member by member, with sender-attributed message fan-out."
+
+what_you_learn:
+  - "Run three isolated `logoscore` daemons on one host, selected by `--config-dir`"
+  - "Create a group with `create_group_conversation()` and grow it with `add_group_member` — including an add proposed by a non-creator member"
+  - "Why a group join lands asynchronously (consensus + steward commit + welcome), and how to observe it by polling `list_conversations`"
+  - "How every member shares one conversation id, and how `get_messages` attributes each inbound message to its sender's account address"
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+  - "**A Linux or macOS machine.** Nix provides every toolchain (Qt, CMake, cargo, rustc) during the builds."
+  - "**`jq`** on `PATH` (used to read the JSON the CLI prints). GitHub runners ship it; locally, run the spec inside `nix shell nixpkgs#jq`."
+  - "**Network access.** The three delivery nodes discover each other over the `logos.test` Waku fleet; an isolated sandbox won't complete the exchange. Expect ~5-40s to reach Online, minutes per membership change, and up to ~2 min for messages to propagate."
+
+sections:
+  - title: "Build the tools and the two modules"
+    step: true
+    text: |
+      Two tools drive the exchange: `logoscore` (the headless module runtime,
+      which also bundles `capability_module` under `logos/modules/`) and `lgpm`
+      (the package installer). Then the two modules the daemons load:
+      `chat_module`, and its runtime dependency `delivery_module`.
+    steps:
+      - title: "Build logoscore"
+        run: "nix build 'github:logos-co/logos-logoscore-cli' --out-link ./logos"
+        check_file: "logos/bin/logoscore"
+      - title: "Build lgpm"
+        run: "nix build 'github:logos-co/logos-package-manager#cli' -o lgpm"
+        check_file: "lgpm/bin/lgpm"
+      - title: "Build chat_module (the commit under test)"
+        run: "nix build \"github:logos-co/logos-chat-module{release}#lgx\" -o chat-lgx"
+        code_block: "nix build 'github:logos-co/logos-chat-module#lgx' -o chat-lgx"
+        check_file: "chat-lgx"
+      - title: "Build delivery_module (chat_module's runtime dependency)"
+        run: "nix build \"github:logos-co/logos-chat-module{release}#delivery_module-lgx\" -o delivery-lgx"
+        code_block: "nix build 'github:logos-co/logos-chat-module#delivery_module-lgx' -o delivery-lgx"
+        check_file: "delivery-lgx"
+        post_text: |
+          Built from `chat_module`'s own flake, so the running `delivery_module`
+          is the exact rev `chat_module` is built against.
+
+  - title: "Assemble the modules directory"
+    step: true
+    text: |
+      All three daemons load from one shared modules directory: the
+      `capability_module` that ships with `logoscore`, plus the two `.lgx`s
+      installed on top.
+    steps:
+      - title: "Install the bundled and built modules"
+        run: |
+          mkdir -p modules
+          cp -RL ./logos/modules/. ./modules/
+          ./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file delivery-lgx/*.lgx
+          ./lgpm/bin/lgpm --modules-dir ./modules --allow-unsigned install --file chat-lgx/*.lgx
+        code_block: |
+          mkdir -p modules
+          cp -RL ./logos/modules/. ./modules/                       # bundled capability_module
+          lgpm --modules-dir ./modules --allow-unsigned install --file delivery-lgx/*.lgx
+          lgpm --modules-dir ./modules --allow-unsigned install --file chat-lgx/*.lgx
+        expect_contains:
+          - "Installed to:"
+
+  - title: "Start three isolated daemons"
+    step: true
+    text: |
+      One module is a per-host singleton inside a daemon, so Alice, Bob, and
+      Carol are **separate daemons**, kept apart by `--config-dir` (control
+      socket, client token, persistence) and, in the next step, by distinct
+      `tcp_port`s for their delivery nodes.
+    steps:
+      - run: "mkdir -p alice-data bob-data carol-data"
+      - title: "Start the three daemons"
+        run: |
+          sh -c './logos/bin/logoscore --config-dir alice -D -m ./modules > alice-daemon.log 2>&1 &'
+          sh -c './logos/bin/logoscore --config-dir bob   -D -m ./modules > bob-daemon.log 2>&1 &'
+          sh -c './logos/bin/logoscore --config-dir carol -D -m ./modules > carol-daemon.log 2>&1 &'
+        code_block: |
+          logoscore --config-dir alice -D -m ./modules > alice-daemon.log &
+          logoscore --config-dir bob   -D -m ./modules > bob-daemon.log &
+          logoscore --config-dir carol -D -m ./modules > carol-daemon.log &
+      - title: "Wait for the three control planes to come up"
+        run: |
+          for who in alice bob carol; do
+            up=""
+            for i in $(seq 1 30); do
+              if ./logos/bin/logoscore --config-dir "$who" list-modules >/dev/null 2>&1; then
+                up=1; echo "${who}_DAEMON_UP"; break
+              fi
+              sleep 1
+            done
+            if [ -z "$up" ]; then echo "$who daemon never came up" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; fi
+          done
+        code_block: |
+          # poll each daemon's control plane until it answers
+          logoscore --config-dir alice list-modules
+          logoscore --config-dir bob   list-modules
+          logoscore --config-dir carol list-modules
+        expect_contains:
+          - "alice_DAEMON_UP"
+          - "bob_DAEMON_UP"
+          - "carol_DAEMON_UP"
+      - title: "Load chat_module on each (delivery_module auto-resolves)"
+        run: |
+          ./logos/bin/logoscore --config-dir alice load-module chat_module
+          ./logos/bin/logoscore --config-dir bob   load-module chat_module
+          ./logos/bin/logoscore --config-dir carol load-module chat_module
+        code_block: |
+          logoscore --config-dir alice load-module chat_module
+          logoscore --config-dir bob   load-module chat_module
+          logoscore --config-dir carol load-module chat_module
+        expect_contains:
+          - "delivery_module"
+
+  - title: "Bring the three instances online"
+    step: true
+    text: |
+      `init(instance_path, delivery_preset, tcp_port)` returns immediately and
+      kicks off the delivery bootstrap asynchronously; readiness arrives later
+      when `status().delivery_state` flips to `online`. All three are
+      initialised **first** so their cold Waku bootstraps overlap, then each is
+      polled; the wait is ~the slowest of the three, not their sum.
+    steps:
+      - title: "Initialise Alice (60020), Bob (60021), and Carol (60022)"
+        run: |
+          for who in alice bob carol; do
+            case "$who" in alice) port=60020;; bob) port=60021;; carol) port=60022;; esac
+            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init "$PWD/${who}-data" logos.test "$port")
+            echo "$out"
+            echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "$who init failed: $out" >&2; exit 1; }
+            echo "${who}_INIT_OK"
+          done
+        code_block: |
+          logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60020
+          logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60021
+          logoscore --config-dir carol call chat_module init "$PWD/carol-data" logos.test 60022
+        expect_contains:
+          - "alice_INIT_OK"
+          - "bob_INIT_OK"
+          - "carol_INIT_OK"
+        post_text: |
+          Distinct `instance_path` and `tcp_port` per instance: `tcp_port` is
+          bound for both the Waku TCP listener and the discv5 UDP port, so no
+          two nodes may share one.
+      - title: "Wait for all three to reach Online"
+        run: |
+          for who in alice bob carol; do
+            online=""
+            for i in $(seq 1 60); do
+              out=$(./logos/bin/logoscore --config-dir "$who" call chat_module status 2>/dev/null || true)
+              case "$out" in
+                *'"delivery_state":"online"'*) online=1; echo "${who}_ONLINE"; break;;
+                *'"delivery_state":"error"'*) echo "$who delivery error: $out" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1;;
+              esac
+              sleep 2
+            done
+            if [ -z "$online" ]; then echo "$who never came online" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; fi
+          done
+        code_block: |
+          # poll status() until delivery_state == online (fail fast on "error")
+          logoscore --config-dir alice call chat_module status
+          logoscore --config-dir bob   call chat_module status
+          logoscore --config-dir carol call chat_module status
+        expect_contains:
+          - "alice_ONLINE"
+          - "bob_ONLINE"
+          - "carol_ONLINE"
+
+  - title: "Create the group and grow it to three members"
+    step: true
+    text: |
+      Alice creates the group (a one-member conversation) and invites Bob by
+      his address. Once Bob is in, **Bob** — not the creator — invites Carol:
+      any member can propose an add. Each add is agreed by the group, committed
+      by the steward after the commit-inactivity window, and the welcome then
+      travels to the invited instance, so the polls below wait minutes, not
+      seconds.
+    steps:
+      - title: "Everyone publishes an address"
+        run: |
+          for who in alice bob carol; do
+            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module get_address)
+            echo "$out" | jq -j '.result' > "${who}-addr.txt"
+            echo "${who} address: $(cat ${who}-addr.txt)"
+          done
+        code_block: |
+          logoscore --config-dir alice call chat_module get_address | jq -j '.result' > alice-addr.txt
+          logoscore --config-dir bob   call chat_module get_address | jq -j '.result' > bob-addr.txt
+          logoscore --config-dir carol call chat_module get_address | jq -j '.result' > carol-addr.txt
+        expect_contains:
+          - "alice address:"
+          - "bob address:"
+          - "carol address:"
+        post_text: |
+          The address is the instance's account address. Peers use it both to
+          open 1:1 conversations and to invite the instance into groups; the
+          key material behind it was published to the registry during `init`.
+      - title: "Alice creates the group"
+        run: |
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_group_conversation)
+          echo "$out"
+          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "create_group_conversation failed: $out" >&2; exit 1; }
+          echo "$out" | jq -j '.result.value' > group-id.txt
+          echo "group id: $(cat group-id.txt)"
+        code_block: |
+          logoscore --config-dir alice call chat_module create_group_conversation
+        expect_contains:
+          - '"status":"ok"'
+          - "group id:"
+        post_text: |
+          The group starts with Alice as its only member; `result.value` is the
+          conversation id **every** member will see once they join.
+      - title: "Alice invites Bob"
+        run: |
+          gid=$(cat group-id.txt)
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module add_group_member "$gid" @bob-addr.txt)
+          echo "$out"
+          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "add_group_member failed: $out" >&2; exit 1; }
+          echo "BOB_INVITED"
+        code_block: |
+          logoscore --config-dir alice call chat_module add_group_member "$GROUP_ID" @bob-addr.txt
+        expect_contains:
+          - "BOB_INVITED"
+        post_text: |
+          The call returns as soon as the add is proposed; the commit and the
+          welcome happen asynchronously in the group.
+      - title: "Bob joins"
+        run: |
+          gid=$(cat group-id.txt)
+          for i in $(seq 1 150); do
+            got=$(./logos/bin/logoscore --config-dir bob call chat_module list_conversations 2>/dev/null | jq -r --arg id "$gid" '.result[]? | select(.convo_id == $id) | .convo_id' || true)
+            if [ -n "$got" ]; then echo "BOB_IN_GROUP $got"; break; fi
+            sleep 4
+          done
+          [ -n "$got" ] || { echo "bob never joined the group" >&2; tail -n 40 bob-daemon.log >&2; exit 1; }
+        code_block: |
+          # poll until the group id appears in Bob's conversations
+          logoscore --config-dir bob call chat_module list_conversations
+        expect_contains:
+          - "BOB_IN_GROUP"
+        post_text: |
+          Bob's instance observes the group under the **same** conversation id
+          Alice created — one id per group, shared by all members.
+      - title: "Bob invites Carol (a non-creator add)"
+        run: |
+          gid=$(cat group-id.txt)
+          out=$(./logos/bin/logoscore --config-dir bob call chat_module add_group_member "$gid" @carol-addr.txt)
+          echo "$out"
+          echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "add_group_member failed: $out" >&2; exit 1; }
+          echo "CAROL_INVITED"
+        code_block: |
+          logoscore --config-dir bob call chat_module add_group_member "$GROUP_ID" @carol-addr.txt
+        expect_contains:
+          - "CAROL_INVITED"
+        post_text: |
+          Group membership is symmetric: any member can propose an add, the
+          group agrees, the steward commits, and the proposer's instance routes
+          the welcome to the newcomer.
+      - title: "Carol joins"
+        run: |
+          gid=$(cat group-id.txt)
+          for i in $(seq 1 150); do
+            got=$(./logos/bin/logoscore --config-dir carol call chat_module list_conversations 2>/dev/null | jq -r --arg id "$gid" '.result[]? | select(.convo_id == $id) | .convo_id' || true)
+            if [ -n "$got" ]; then echo "CAROL_IN_GROUP $got"; break; fi
+            sleep 4
+          done
+          [ -n "$got" ] || { echo "carol never joined the group" >&2; tail -n 40 carol-daemon.log >&2; exit 1; }
+        code_block: |
+          # poll until the group id appears in Carol's conversations
+          logoscore --config-dir carol call chat_module list_conversations
+        expect_contains:
+          - "CAROL_IN_GROUP"
+
+  - title: "Messages fan out to every member, with senders attributed"
+    step: true
+    text: |
+      One send reaches every other member. Each receiver's `get_messages`
+      attributes the message to the sender's account address (the same string
+      that instance's `get_address` returned), verified against the account →
+      device directory on delivery.
+    steps:
+      - title: "Alice messages the group"
+        run: |
+          gid=$(cat group-id.txt)
+          sent=""
+          for i in $(seq 1 20); do
+            out=$(./logos/bin/logoscore --config-dir alice call chat_module send_message "$gid" hello-group 2>/dev/null || true)
+            if echo "$out" | jq -e '.result.success == true' >/dev/null 2>&1; then sent=1; echo "ALICE_SENT"; break; fi
+            sleep 5
+          done
+          [ -n "$sent" ] || { echo "alice could not send: $out" >&2; exit 1; }
+        code_block: |
+          logoscore --config-dir alice call chat_module send_message "$GROUP_ID" hello-group
+        expect_contains:
+          - "ALICE_SENT"
+        post_text: |
+          The short retry loop covers the group's brief post-commit windows in
+          which sends are rejected (the group is finalizing a membership
+          change).
+      - title: "Bob and Carol both receive it, attributed to Alice"
+        run: |
+          gid=$(cat group-id.txt)
+          addr=$(cat alice-addr.txt)
+          for who in bob carol; do
+            got=""
+            for i in $(seq 1 60); do
+              ok=$(./logos/bin/logoscore --config-dir "$who" call chat_module get_messages "$gid" 2>/dev/null | jq -r --arg a "$addr" '.result[]? | select(.content == "hello-group") | select(.sender == $a) | .content' || true)
+              if [ -n "$ok" ]; then got=1; echo "$(echo "$who" | tr a-z A-Z)_GOT_HELLO_FROM_ALICE"; break; fi
+              sleep 4
+            done
+            [ -n "$got" ] || { echo "$who never received alice's message" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; }
+          done
+        code_block: |
+          # each member sees the message with sender == Alice's address
+          logoscore --config-dir bob   call chat_module get_messages "$GROUP_ID"
+          logoscore --config-dir carol call chat_module get_messages "$GROUP_ID"
+        expect_contains:
+          - "BOB_GOT_HELLO_FROM_ALICE"
+          - "CAROL_GOT_HELLO_FROM_ALICE"
+      - title: "Carol replies to the group"
+        run: |
+          gid=$(cat group-id.txt)
+          sent=""
+          for i in $(seq 1 20); do
+            out=$(./logos/bin/logoscore --config-dir carol call chat_module send_message "$gid" carol-checking-in 2>/dev/null || true)
+            if echo "$out" | jq -e '.result.success == true' >/dev/null 2>&1; then sent=1; echo "CAROL_SENT"; break; fi
+            sleep 5
+          done
+          [ -n "$sent" ] || { echo "carol could not send: $out" >&2; exit 1; }
+        code_block: |
+          logoscore --config-dir carol call chat_module send_message "$GROUP_ID" carol-checking-in
+        expect_contains:
+          - "CAROL_SENT"
+      - title: "Alice and Bob both receive Carol's reply"
+        run: |
+          gid=$(cat group-id.txt)
+          addr=$(cat carol-addr.txt)
+          for who in alice bob; do
+            got=""
+            for i in $(seq 1 60); do
+              ok=$(./logos/bin/logoscore --config-dir "$who" call chat_module get_messages "$gid" 2>/dev/null | jq -r --arg a "$addr" '.result[]? | select(.content == "carol-checking-in") | select(.sender == $a) | .content' || true)
+              if [ -n "$ok" ]; then got=1; echo "$(echo "$who" | tr a-z A-Z)_GOT_CAROL_REPLY"; break; fi
+              sleep 4
+            done
+            [ -n "$got" ] || { echo "$who never received carol's reply" >&2; tail -n 40 "${who}-daemon.log" >&2; exit 1; }
+          done
+        code_block: |
+          logoscore --config-dir alice call chat_module get_messages "$GROUP_ID"
+          logoscore --config-dir bob   call chat_module get_messages "$GROUP_ID"
+        expect_contains:
+          - "ALICE_GOT_CAROL_REPLY"
+          - "BOB_GOT_CAROL_REPLY"
+        post_text: |
+          The newest member's messages reach the founding members and vice
+          versa: all three instances share one MLS group at one epoch, and
+          every message is end-to-end encrypted and sender-attributed.
+
+  - title: "Stop the daemons"
+    step: true
+    steps:
+      - title: "Shut all three down gracefully"
+        run: |
+          ./logos/bin/logoscore --config-dir alice stop || true
+          ./logos/bin/logoscore --config-dir bob   stop || true
+          ./logos/bin/logoscore --config-dir carol stop || true
+        code_block: |
+          logoscore --config-dir alice stop
+          logoscore --config-dir bob   stop
+          logoscore --config-dir carol stop
+        post_text: "Always stop through the control socket rather than killing the process group: three daemons share one shell here."

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_module",
   "display_name": "Chat Module",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Chat module for Logos",
   "author": "Logos Core Team",
   "type": "core",

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_module",
   "display_name": "Chat Module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Chat module for Logos",
   "author": "Logos Core Team",
   "type": "core",

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "chat_module",
   "display_name": "Chat Module",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Chat module for Logos",
   "author": "Logos Core Team",
   "type": "core",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "crypto",
  "hex",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "chat_module"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "hex",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "base64",
  "crossbeam-channel",
@@ -1479,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2891,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3228,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "logos-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "crypto",
  "hex",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "chat_module"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crossbeam-channel",
  "hex",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "base64",
  "crossbeam-channel",
@@ -1479,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2891,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3228,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "logos-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=c243c9cad5fd761cdbf995437e18df57abf33d2e#c243c9cad5fd761cdbf995437e18df57abf33d2e"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "crypto",
  "hex",
@@ -1250,7 +1250,9 @@ name = "chat_module"
 version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
+ "hex",
  "libchat",
+ "logos-account",
  "logos-chat",
  "logos-rust-sdk",
  "serde",
@@ -1304,15 +1306,17 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "base64",
  "crossbeam-channel",
  "crypto",
  "hex",
  "libchat",
+ "logos-account",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "storage",
  "thiserror",
  "tracing",
@@ -1475,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1608,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?tag=v4.0.0#425203056d4586115beef6559b49560095a15256"
+source = "git+https://github.com/vacp2p/de-mls?branch=main#2b3eed17723d4fb12037ef8cfb1f5e8c115b09a1"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",
@@ -1733,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2887,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "alloy",
  "base64",
@@ -3224,17 +3228,18 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "crypto",
- "libchat",
+ "hex",
  "shared-traits",
+ "thiserror",
 ]
 
 [[package]]
 name = "logos-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4858,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "crypto",
 ]
@@ -4945,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git#0d38dd80b75f2be3e4320caa5491e44d50ad8436"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=518d6c1302292f994f4e0d10c589800245dc3a75#518d6c1302292f994f4e0d10c589800245dc3a75"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "crypto",
  "hex",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "base64",
  "crossbeam-channel",
@@ -1479,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2891,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3228,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "logos-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=89afa0b0866164735a33c9f374addbd4467e1348#89afa0b0866164735a33c9f374addbd4467e1348"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=6691ef1f2465f491205a02de3e08aeb60fda09ea#6691ef1f2465f491205a02de3e08aeb60fda09ea"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "chat_module"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "hex",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name     = "chat_module"
-version  = "0.3.0"
+version  = "0.4.0"
 edition  = "2021"
 
 [lib]

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -23,10 +23,20 @@ panic = "abort"
 # libchat's high-level threaded client (package renamed `client` -> `logos-chat`).
 # It owns the inbound worker that drives `Core::handle_payload` and surfaces
 # observations as `Event`s on a channel the module drains.
-logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat" }
-# The umbrella `libchat` crate, for `ChatStorage`: the builder's `storage_config`
-# panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat" }
+# rev pins fix/signer-scoped-directv1 (origin/main plus the signer-scoped invite
+# routing rework: accounts resolve to signer ids at the client layer, and the
+# signer's verifying-key hex is the registry key, inbox subscription, and Welcome
+# routing target, so a DirectV1 Welcome routes over the devnet HttpRegistry).
+# Drop the rev once the rework merges to main.
+logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
+# The umbrella `libchat` crate, for `ChatStorage`: the builder's
+# `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
+# `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
+# account identity that signs this installation's device bundle and whose key is
+# the shared account address. Enable `dev` on our own dep so its availability
+# doesn't hinge on another crate happening to turn the feature on.
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"
@@ -38,6 +48,9 @@ logos-rust-sdk = { path = "../logos-rust-sdk-src" }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"
+# Hex-encodes the account verifying key as this installation's shared address,
+# and the delegate device key into the account's signed device bundle.
+hex            = "0.4"
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name     = "chat_module"
-version  = "0.1.1"
+version  = "0.2.0"
 edition  = "2021"
 
 [lib]
@@ -23,20 +23,19 @@ panic = "abort"
 # libchat's high-level threaded client (package renamed `client` -> `logos-chat`).
 # It owns the inbound worker that drives `Core::handle_payload` and surfaces
 # observations as `Event`s on a channel the module drains.
-# rev pins fix/signer-scoped-directv1 (origin/main plus the signer-scoped invite
-# routing rework: accounts resolve to signer ids at the client layer, and the
-# signer's verifying-key hex is the registry key, inbox subscription, and Welcome
-# routing target, so a DirectV1 Welcome routes over the devnet HttpRegistry).
-# Drop the rev once the rework merges to main.
-logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
+# rev pins feat/groupv2-client: origin/main plus the GroupV2 client surface
+# this module's group ops need (create_group_conversation /
+# add_group_members, injectable GroupV2 timing). Drop the rev once it merges
+# to main.
+logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "518d6c1302292f994f4e0d10c589800245dc3a75" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -27,15 +27,15 @@ panic = "abort"
 # ops need (create_group_conversation / add_group_members, injectable GroupV2
 # timing), plus the group roster (`group_members`) and the honest DirectV1
 # display class this module now surfaces. Drop the rev once it merges to main.
-logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
+logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "6691ef1f2465f491205a02de3e08aeb60fda09ea" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "6691ef1f2465f491205a02de3e08aeb60fda09ea" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "6691ef1f2465f491205a02de3e08aeb60fda09ea" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name     = "chat_module"
-version  = "0.2.0"
+version  = "0.3.0"
 edition  = "2021"
 
 [lib]
@@ -23,19 +23,19 @@ panic = "abort"
 # libchat's high-level threaded client (package renamed `client` -> `logos-chat`).
 # It owns the inbound worker that drives `Core::handle_payload` and surfaces
 # observations as `Event`s on a channel the module drains.
-# rev pins feat/groupv2-client: origin/main plus the GroupV2 client surface
-# this module's group ops need (create_group_conversation /
-# add_group_members, injectable GroupV2 timing). Drop the rev once it merges
-# to main.
-logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
+# rev pins feat/groupv2-roster: the GroupV2 client surface this module's group
+# ops need (create_group_conversation / add_group_members, injectable GroupV2
+# timing), plus the group roster (`group_members`) and the honest DirectV1
+# display class this module now surfaces. Drop the rev once it merges to main.
+logos-chat     = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-chat", rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "c243c9cad5fd761cdbf995437e18df57abf33d2e" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "89afa0b0866164735a33c9f374addbd4467e1348" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -40,10 +40,14 @@ module chat_module {
   ; --- identity ---
   method get_installation_name() -> tstr
   method set_installation_name(name: tstr) -> result
-  method create_intro_bundle() -> result
+  ; The local installation address, shared out-of-band so a peer can open a
+  ; conversation with this installation via create_conversation.
+  method get_address() -> tstr
 
   ; --- conversations & messages ---
-  method create_conversation(peer_intro_bundle: tstr, initial_content: tstr) -> result
+  ; Open a 1:1 conversation with the peer at peer_address (their get_address).
+  ; Sends the cryptographic invite; the first message follows via send_message.
+  method create_conversation(peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
   method send_message(convo_id: tstr, content: tstr) -> result

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -10,7 +10,7 @@
 ; (no generated C++ struct) — they document the shape and "light up" if the
 ; generators gain struct support.
 module chat_module {
-  version "0.2.0"
+  version "0.3.0"
   description "Chat module for Logos: e2e-encrypted conversations over delivery_module."
   category "chat"
   depends [delivery_module]
@@ -21,6 +21,8 @@ module chat_module {
     ? nickname: tstr
     message_count: int
     last_activity_ms: int
+    ; "direct" (1:1) or "group". PrivateV1 and DirectV1 are both "direct".
+    kind: tstr
   }
   type Message {
     from_self: bool
@@ -60,6 +62,11 @@ module chat_module {
   method add_group_member(convo_id: tstr, peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
+  ; The roster of a group conversation, one member per element: each is the
+  ; member's directory-verified account address, or its device id when the
+  ; member claims no account (the same convention `sender` uses). Errors when
+  ; convo_id names a direct (non-group) conversation.
+  method list_group_members(convo_id: tstr) -> [tstr]
   method send_message(convo_id: tstr, content: tstr) -> result
   method set_conversation_nickname(convo_id: tstr, nickname: tstr) -> result
   method delete_conversation(convo_id: tstr) -> result
@@ -72,7 +79,8 @@ module chat_module {
   ; when the sender claims no account.
   event message_received(convo_id: tstr, content: tstr, timestamp_ms: int, sender: tstr)
   event message_sent(convo_id: tstr, content: tstr, timestamp_ms: int)
-  event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr)
+  ; kind: "direct" (1:1) or "group", matching the Conversation record's field.
+  event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr, kind: tstr)
   event conversation_updated(convo_id: tstr)
   event conversation_deleted(convo_id: tstr)
   event delivery_state_changed(delivery_state: tstr, detail: tstr)

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -10,7 +10,7 @@
 ; (no generated C++ struct) — they document the shape and "light up" if the
 ; generators gain struct support.
 module chat_module {
-  version "0.1.1"
+  version "0.2.0"
   description "Chat module for Logos: e2e-encrypted conversations over delivery_module."
   category "chat"
   depends [delivery_module]
@@ -26,6 +26,9 @@ module chat_module {
     from_self: bool
     content: tstr
     timestamp_ms: int
+    ; Sender's account address (device id if unassociated); unset on
+    ; messages this installation sent.
+    ? sender: tstr
   }
   type Status {
     convo_count: int
@@ -48,6 +51,13 @@ module chat_module {
   ; Open a 1:1 conversation with the peer at peer_address (their get_address).
   ; Sends the cryptographic invite; the first message follows via send_message.
   method create_conversation(peer_address: tstr) -> result
+  ; Create a group conversation with this installation as its only member;
+  ; grow it with add_group_member. Every member sees the returned convo_id.
+  method create_group_conversation() -> result
+  ; Invite the peer at peer_address into an existing group conversation. The
+  ; invite is committed and delivered asynchronously; the peer observes the
+  ; conversation once its instance has joined.
+  method add_group_member(convo_id: tstr, peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
   method send_message(convo_id: tstr, content: tstr) -> result
@@ -58,7 +68,9 @@ module chat_module {
   method status() -> Status
 
   ; --- events ---
-  event message_received(convo_id: tstr, content: tstr, timestamp_ms: int)
+  ; sender: the sender's directory-verified account address, or its device id
+  ; when the sender claims no account.
+  event message_received(convo_id: tstr, content: tstr, timestamp_ms: int, sender: tstr)
   event message_sent(convo_id: tstr, content: tstr, timestamp_ms: int)
   event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr)
   event conversation_updated(convo_id: tstr)

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -10,7 +10,7 @@
 ; (no generated C++ struct) — they document the shape and "light up" if the
 ; generators gain struct support.
 module chat_module {
-  version "0.3.0"
+  version "0.4.0"
   description "Chat module for Logos: e2e-encrypted conversations over delivery_module."
   category "chat"
   depends [delivery_module]
@@ -37,6 +37,11 @@ module chat_module {
     delivery_state: tstr
     detail: tstr
   }
+  type GroupMember {
+    ; The member's directory-verified account address, or empty when the member
+    ; claims no confirmed account (the UI renders these as an unknown account).
+    address: tstr
+  }
 
   ; --- lifecycle ---
   method init(instance_path: tstr, delivery_preset: tstr, tcp_port: int) -> result
@@ -62,11 +67,9 @@ module chat_module {
   method add_group_member(convo_id: tstr, peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
-  ; The roster of a group conversation, one member per element: each is the
-  ; member's directory-verified account address, or its device id when the
-  ; member claims no account (the same convention `sender` uses). Errors when
+  ; The roster of a group conversation, one GroupMember per element. Errors when
   ; convo_id names a direct (non-group) conversation.
-  method list_group_members(convo_id: tstr) -> [tstr]
+  method list_group_members(convo_id: tstr) -> [GroupMember]
   method send_message(convo_id: tstr, content: tstr) -> result
   method set_conversation_nickname(convo_id: tstr, nickname: tstr) -> result
   method delete_conversation(convo_id: tstr) -> result

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -370,6 +370,45 @@ pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreErro
     Ok(chat_id)
 }
 
+/// Create a GroupV2 conversation with this installation as its only member;
+/// peers are invited afterwards via [`add_group_member`]. Returns the
+/// conversation id, which every member observes once joined.
+pub(crate) fn create_group_conversation() -> Result<String, CoreError> {
+    let chat_id = with_client(|client| client.create_group_conversation(&[]))?
+        .map_err(|e| CoreError::Internal(format!("create_group_conversation failed: {e:?}")))?;
+
+    let label = short_label(&chat_id).to_owned();
+    with_display_mut(|d| {
+        d.state.chats.insert(
+            chat_id.clone(),
+            ChatSession {
+                chat_id: chat_id.clone(),
+                nickname: None,
+                messages: Vec::new(),
+            },
+        );
+        persist(d)
+    })?;
+    crate::emit_conversation_created(&chat_id, true, &label);
+
+    Ok(chat_id)
+}
+
+/// Invite the peer at `peer_address` (all its endorsed devices) into an
+/// existing group conversation. The group's steward commits the add and the
+/// welcome is delivered asynchronously, so the peer joins some time after
+/// this returns.
+pub(crate) fn add_group_member(convo_id: &str, peer_address: &str) -> Result<(), CoreError> {
+    if !with_display(|d| d.state.chats.contains_key(convo_id)) {
+        return Err(CoreError::NotFound);
+    }
+
+    with_client(|client| client.add_group_members(convo_id, &[peer_address]))?
+        .map_err(|e| CoreError::Internal(format!("add_group_member failed: {e:?}")))?;
+    crate::emit_conversation_updated(convo_id);
+    Ok(())
+}
+
 pub(crate) fn list_conversations() -> serde_json::Value {
     with_display(|d| {
         let items: Vec<ConversationSummary> = d
@@ -420,6 +459,7 @@ pub(crate) fn send_message(convo_id: &str, content: &str) -> Result<(), CoreErro
                 from_self: true,
                 content: content.to_string(),
                 timestamp_ms: ts,
+                sender: None,
             });
         }
         persist(d)
@@ -511,10 +551,11 @@ pub(crate) fn record_conversation_started(convo_id: &str) {
 }
 
 /// Record an inbound message (the client's `MessageReceived` event) and surface
-/// it. No-op for a locally-deleted conversation; an unknown conversation is
+/// it. `sender` is the sender's account address (device id if unassociated).
+/// No-op for a locally-deleted conversation; an unknown conversation is
 /// created defensively (the preceding `ConversationStarted` normally creates it
 /// first). Called from the event consumer thread; takes only the display lock.
-pub(crate) fn record_message_received(convo_id: &str, content: &[u8]) {
+pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &str) {
     with_display_mut(|d| {
         if d.state.deleted.contains(convo_id) {
             return;
@@ -534,8 +575,9 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8]) {
             from_self: false,
             content: text.clone(),
             timestamp_ms: ts,
+            sender: Some(sender.to_owned()),
         });
-        crate::emit_message_received(convo_id, &text, ts as i64);
+        crate::emit_message_received(convo_id, &text, ts as i64, sender);
 
         if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed after inbound message: {e}");

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -414,14 +414,15 @@ pub(crate) fn add_group_member(convo_id: &str, peer_address: &str) -> Result<(),
     Ok(())
 }
 
-/// A group member's display string: its directory-verified account address, or
-/// its device id when the member claims no account (the `sender` convention).
+/// A group member's directory-verified account address, or an empty string when
+/// no account is confirmed (an unassociated or unconfirmable member). The empty
+/// string is the roster's "no account" signal, which the UI renders as an
+/// unknown-account placeholder.
 fn member_address(member: logos_chat::GroupMember) -> String {
     member
         .account
-        .unwrap_or(member.local_identity)
-        .as_str()
-        .to_string()
+        .map(|account| account.as_str().to_string())
+        .unwrap_or_default()
 }
 
 /// The roster of the group conversation `convo_id`, one member address per
@@ -636,18 +637,20 @@ mod tests {
     use libchat::IdentId;
     use logos_chat::GroupMember;
 
+    /// A verified account surfaces its address; a member with no confirmed
+    /// account surfaces the empty "no account" signal, not its device id.
     #[test]
-    fn member_address_prefers_account_then_device() {
+    fn member_address_is_account_or_empty() {
         let verified = GroupMember {
             account: Some(IdentId::new("acct-addr")),
             local_identity: IdentId::new("device-id"),
         };
         assert_eq!(member_address(verified), "acct-addr");
 
-        let device_only = GroupMember {
+        let no_account = GroupMember {
             account: None,
             local_identity: IdentId::new("device-id"),
         };
-        assert_eq!(member_address(device_only), "device-id");
+        assert_eq!(member_address(no_account), "");
     }
 }

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -28,7 +28,9 @@ use crate::module::{
     module, now_ms, short_label, with_display, with_display_mut, Client, DeliveryState,
     DeliveryStateKind, Display, ModuleState, PERSISTENCE_ENABLED,
 };
-use crate::persistence::{load_state, save_state, AppState, ChatSession, DisplayMessage};
+use crate::persistence::{
+    load_state, save_state, AppState, ChatSession, ConversationKind, DisplayMessage,
+};
 
 /// Failure modes for the steady-state methods (post-`initialize`).
 #[derive(Debug, thiserror::Error)]
@@ -66,6 +68,7 @@ struct ConversationSummary {
     nickname: Option<String>,
     message_count: usize,
     last_activity_ms: u64,
+    kind: ConversationKind,
 }
 
 /// `status` payload — mirrors the `Status` record.
@@ -360,12 +363,13 @@ pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreErro
             ChatSession {
                 chat_id: chat_id.clone(),
                 nickname: None,
+                kind: ConversationKind::Direct,
                 messages: Vec::new(),
             },
         );
         persist(d)
     })?;
-    crate::emit_conversation_created(&chat_id, true, &peer_label);
+    crate::emit_conversation_created(&chat_id, true, &peer_label, ConversationKind::Direct.as_str());
 
     Ok(chat_id)
 }
@@ -384,12 +388,13 @@ pub(crate) fn create_group_conversation() -> Result<String, CoreError> {
             ChatSession {
                 chat_id: chat_id.clone(),
                 nickname: None,
+                kind: ConversationKind::Group,
                 messages: Vec::new(),
             },
         );
         persist(d)
     })?;
-    crate::emit_conversation_created(&chat_id, true, &label);
+    crate::emit_conversation_created(&chat_id, true, &label, ConversationKind::Group.as_str());
 
     Ok(chat_id)
 }
@@ -409,6 +414,41 @@ pub(crate) fn add_group_member(convo_id: &str, peer_address: &str) -> Result<(),
     Ok(())
 }
 
+/// A group member's display string: its directory-verified account address, or
+/// its device id when the member claims no account (the `sender` convention).
+fn member_address(member: logos_chat::GroupMember) -> String {
+    member
+        .account
+        .unwrap_or(member.local_identity)
+        .as_str()
+        .to_string()
+}
+
+/// The roster of the group conversation `convo_id`, one member address per
+/// element (see [`member_address`]). This is a plain list with no error channel,
+/// mirroring `get_messages`: an unknown or non-group conversation, or a client
+/// error, yields an empty array (the client error is logged).
+pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
+    let empty = || serde_json::Value::Array(vec![]);
+    if !with_display(|d| d.state.chats.contains_key(convo_id)) {
+        return empty();
+    }
+    match with_client(|client| client.group_members(convo_id)) {
+        Ok(Ok(members)) => {
+            let addrs: Vec<String> = members.into_iter().map(member_address).collect();
+            serde_json::to_value(addrs).unwrap_or_else(|_| empty())
+        }
+        Ok(Err(e)) => {
+            eprintln!("chat_module: list_group_members failed: {e:?}");
+            empty()
+        }
+        Err(e) => {
+            eprintln!("chat_module: list_group_members: {e}");
+            empty()
+        }
+    }
+}
+
 pub(crate) fn list_conversations() -> serde_json::Value {
     with_display(|d| {
         let items: Vec<ConversationSummary> = d
@@ -420,6 +460,7 @@ pub(crate) fn list_conversations() -> serde_json::Value {
                 nickname: s.nickname.clone(),
                 message_count: s.messages.len(),
                 last_activity_ms: s.messages.last().map(|m| m.timestamp_ms).unwrap_or(0),
+                kind: s.kind,
             })
             .collect();
         serde_json::to_value(items).unwrap_or_else(|_| serde_json::Value::Array(vec![]))
@@ -523,10 +564,10 @@ pub(crate) fn set_delivery_state(d: &mut Display, state: DeliveryStateKind, deta
 }
 
 /// Record a newly-observed conversation (the client's `ConversationStarted`
-/// event) and surface it. No-op for a locally-deleted or already-known
-/// conversation. Called from the event consumer thread; takes only the display
-/// lock, so it never waits on the client.
-pub(crate) fn record_conversation_started(convo_id: &str) {
+/// event) and surface it, classed by `kind`. No-op for a locally-deleted or
+/// already-known conversation. Called from the event consumer thread; takes only
+/// the display lock, so it never waits on the client.
+pub(crate) fn record_conversation_started(convo_id: &str, kind: ConversationKind) {
     with_display_mut(|d| {
         // libchat retains crypto state across local deletes, so we still observe
         // events for deleted convos.
@@ -538,10 +579,11 @@ pub(crate) fn record_conversation_started(convo_id: &str) {
             ChatSession {
                 chat_id: convo_id.to_owned(),
                 nickname: None,
+                kind,
                 messages: Vec::new(),
             },
         );
-        crate::emit_conversation_created(convo_id, false, short_label(convo_id));
+        crate::emit_conversation_created(convo_id, false, short_label(convo_id), kind.as_str());
 
         // Event consumer has no caller to return to; log a failed write.
         if let Err(e) = save_display(d) {
@@ -569,6 +611,9 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
             .or_insert_with(|| ChatSession {
                 chat_id: convo_id.to_owned(),
                 nickname: None,
+                // Defensive fallback: ConversationStarted normally creates the
+                // session with the real kind before any message lands here.
+                kind: ConversationKind::default(),
                 messages: Vec::new(),
             });
         session.messages.push(DisplayMessage {
@@ -583,4 +628,26 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
             eprintln!("chat_module: save_state failed after inbound message: {e}");
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::member_address;
+    use libchat::IdentId;
+    use logos_chat::GroupMember;
+
+    #[test]
+    fn member_address_prefers_account_then_device() {
+        let verified = GroupMember {
+            account: Some(IdentId::new("acct-addr")),
+            local_identity: IdentId::new("device-id"),
+        };
+        assert_eq!(member_address(verified), "acct-addr");
+
+        let device_only = GroupMember {
+            account: None,
+            local_identity: IdentId::new("device-id"),
+        };
+        assert_eq!(member_address(device_only), "device-id");
+    }
 }

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -6,20 +6,29 @@
 //! from the `ChatModule` trait implementation.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use libchat::ChatStorage;
-use logos_chat::{ChatClientBuilder, StorageConfig};
+use logos_account::TestLogosAccount;
+use logos_chat::{ChatClientBuilder, DelegateSigner, HttpRegistry, StorageConfig};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
+
+/// The devnet KeyPackage registry DirectV1 uses to publish this installation's
+/// key package and fetch a peer's. Hardcoded for now; a configurable endpoint is
+/// a future enhancement (the wiring is behind libchat's `RegistrationService`,
+/// so swapping it later is localized).
+const DEFAULT_REGISTRY_URL: &str = "https://devnet.chat-kc.logos.co";
+
 use crate::module::{
     module, now_ms, short_label, with_display, with_display_mut, Client, DeliveryState,
-    DeliveryStateKind, Display, ModuleState,
+    DeliveryStateKind, Display, ModuleState, PERSISTENCE_ENABLED,
 };
-use crate::persistence::{load_state, save_state, ChatSession, DisplayMessage};
+use crate::persistence::{load_state, save_state, AppState, ChatSession, DisplayMessage};
 
 /// Failure modes for the steady-state methods (post-`initialize`).
 #[derive(Debug, thiserror::Error)]
@@ -73,13 +82,21 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     fs::create_dir_all(instance_path)
         .map_err(|e| InitError::Internal(format!("cannot create instance_path: {e}")))?;
 
-    let db_path = format!("{instance_path}/identity.db");
-    // Static key derived from the instance path. Not secret; satisfies
-    // SQLCipher's keying requirement. A user-provided passphrase is a
-    // future enhancement.
-    let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
-    let storage = ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
-        .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?;
+    // Storage backs libchat's identity and MLS/crypto state. Ephemeral by
+    // default (see `PERSISTENCE_ENABLED`): DirectV1 has no reload path yet, so an
+    // in-memory store is honest about chats not surviving a restart. The
+    // SQLCipher path stays here, behind the switch, for when reload lands.
+    let storage = if PERSISTENCE_ENABLED {
+        let db_path = format!("{instance_path}/identity.db");
+        // Static key derived from the instance path. Not secret; satisfies
+        // SQLCipher's keying requirement. A user-provided passphrase is a
+        // future enhancement.
+        let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
+        ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
+            .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?
+    } else {
+        ChatStorage::in_memory()
+    };
 
     // The transport's inbound channel: the bridge worker feeds `inbound_tx` from
     // delivery_module's `messageReceived`, the client's worker drains the rx (via
@@ -96,15 +113,43 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     // node exists; otherwise a partial init would strand a started, unowned node
     // with no workers and no way to stop it. Building the client subscribes the
     // core's inbound addresses, which queue on `subscribe_rx` until the node starts.
-    let (client, events) = ChatClientBuilder::new()
+    //
+    // Identity is ephemeral (see `PERSISTENCE_ENABLED`): a fresh account and
+    // delegate are minted each launch. `TestLogosAccount` holds the account key;
+    // the `DelegateSigner` is a pure device keypair, and the client composes
+    // the account claim into its wire credential from the builder's account
+    // address. The account signs a bundle endorsing the delegate's device key,
+    // published to the registry's account directory below, so a peer given only
+    // the account address resolves this device's key package and opens a
+    // DirectV1 conversation. account != device: the client routes on the
+    // delegate's signer id; the account address is what we share.
+    let account = TestLogosAccount::new();
+    let account_addr = account.address();
+    let delegate = DelegateSigner::random();
+    let device_key = delegate.public_key().clone();
+    let (client, events) = ChatClientBuilder::new(account_addr.clone())
+        .ident(delegate)
         .transport(SdkDelivery::new(inbound_rx, subscribe_tx))
+        .registration(HttpRegistry::new(DEFAULT_REGISTRY_URL))
         .storage(storage)
         .build()
         .map_err(|e| InitError::Internal(format!("client build failed: {e:?}")))?;
+
+    // Endorse the delegate's device key in the registry's account directory so
+    // a peer holding only the account address resolves this device's key package.
+    // (The client registers its own key package during build.)
+    let mut directory = HttpRegistry::new(DEFAULT_REGISTRY_URL);
+    account
+        .add_delegate_signer(&mut directory, &device_key)
+        .map_err(|e| InitError::Internal(format!("publish device bundle failed: {e:?}")))?;
     let intrinsic_name = client.installation_name();
+    // The address a peer needs to open a DirectV1 conversation with us: the
+    // account address (what `client.addr()` returns). Cached in the display
+    // so `get_address` needn't take the client lock.
+    let address = account_addr;
 
     let state_path = PathBuf::from(format!("{instance_path}/history.json"));
-    let state = load_state(&state_path);
+    let state = load_display(&state_path);
 
     // Register listeners before the node starts — `connectionStateChanged`
     // fires during start and is not re-emitted, so a late subscribe misses it.
@@ -141,6 +186,7 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
         d.state_path = state_path;
         d.delivery_state = DeliveryState::initialising();
         d.intrinsic_name = intrinsic_name;
+        d.address = address;
     });
 
     Ok(ModuleState {
@@ -226,7 +272,7 @@ pub(crate) fn shutdown(mut ms: ModuleState) {
     }
     with_display_mut(|d| {
         // Final write; nothing left to propagate to, so log a failure.
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed on shutdown: {e}");
         }
         *d = Display::default();
@@ -247,8 +293,27 @@ fn with_client<R>(f: impl FnOnce(&mut Client) -> R) -> Result<R, CoreError> {
 /// so a failed write surfaces to the caller instead of being silently reported
 /// as success and then vanishing on the next `load_state`.
 fn persist(d: &Display) -> Result<(), CoreError> {
+    save_display(d).map_err(|e| CoreError::Internal(format!("save_state failed: {e}")))
+}
+
+/// Persist the display state, unless persistence is disabled (ephemeral mode),
+/// in which case this is a no-op reporting success. See
+/// [`module::PERSISTENCE_ENABLED`](crate::module::PERSISTENCE_ENABLED).
+fn save_display(d: &Display) -> io::Result<()> {
+    if !PERSISTENCE_ENABLED {
+        return Ok(());
+    }
     save_state(&d.state, &d.state_path)
-        .map_err(|e| CoreError::Internal(format!("save_state failed: {e}")))
+}
+
+/// Load the display state, or start empty when persistence is disabled
+/// (ephemeral mode). See
+/// [`module::PERSISTENCE_ENABLED`](crate::module::PERSISTENCE_ENABLED).
+fn load_display(path: &Path) -> AppState {
+    if !PERSISTENCE_ENABLED {
+        return AppState::default();
+    }
+    load_state(path)
 }
 
 // ── Identity ─────────────────────────────────────────────────────────────────
@@ -268,39 +333,36 @@ pub(crate) fn installation_name() -> String {
     with_display(crate::module::effective_installation_name)
 }
 
-pub(crate) fn create_intro_bundle() -> Result<String, CoreError> {
-    let bytes = with_client(|client| client.create_intro_bundle())?
-        .map_err(|e| CoreError::Internal(format!("create_intro_bundle failed: {e:?}")))?;
-    String::from_utf8(bytes)
-        .map_err(|_| CoreError::Internal("create_intro_bundle: bundle bytes are not UTF-8".into()))
+/// The local installation address, which a peer needs to open a DirectV1
+/// conversation with this installation (pass it to their `create_conversation`).
+/// Read from the cached display value, so it returns the empty string before
+/// `init`.
+pub(crate) fn get_address() -> String {
+    with_display(|d| d.address.clone())
 }
 
 // ── Conversations ────────────────────────────────────────────────────────────
 
-pub(crate) fn create_conversation(bundle: &str, content: &str) -> Result<String, CoreError> {
+/// Open a DirectV1 conversation with `peer_address` (the peer's installation
+/// address from their `get_address`). This sends an MLS Welcome to the peer; the
+/// first message is sent separately via `send_message` once the peer has joined.
+/// Returns the local conversation id.
+pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreError> {
     // libchat op under the client lock. Publish is async (see SdkDelivery), so
     // this returns without blocking on the network.
-    let chat_id =
-        with_client(|client| client.create_conversation(bundle.as_bytes(), content.as_bytes()))?
-            .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
+    let chat_id = with_client(|client| client.create_direct_conversation(peer_address))?
+        .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
 
-    let ts = now_ms();
-
-    let mut session = ChatSession {
-        chat_id: chat_id.clone(),
-        nickname: None,
-        messages: Vec::new(),
-    };
-    if !content.is_empty() {
-        session.messages.push(DisplayMessage {
-            from_self: true,
-            content: content.to_string(),
-            timestamp_ms: ts,
-        });
-    }
     let peer_label = short_label(&chat_id).to_owned();
     with_display_mut(|d| {
-        d.state.chats.insert(chat_id.clone(), session);
+        d.state.chats.insert(
+            chat_id.clone(),
+            ChatSession {
+                chat_id: chat_id.clone(),
+                nickname: None,
+                messages: Vec::new(),
+            },
+        );
         persist(d)
     })?;
     crate::emit_conversation_created(&chat_id, true, &peer_label);
@@ -442,7 +504,7 @@ pub(crate) fn record_conversation_started(convo_id: &str) {
         crate::emit_conversation_created(convo_id, false, short_label(convo_id));
 
         // Event consumer has no caller to return to; log a failed write.
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed after conversation started: {e}");
         }
     });
@@ -475,7 +537,7 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8]) {
         });
         crate::emit_message_received(convo_id, &text, ts as i64);
 
-        if let Err(e) = save_state(&d.state, &d.state_path) {
+        if let Err(e) = save_display(d) {
             eprintln!("chat_module: save_state failed after inbound message: {e}");
         }
     });

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -425,10 +425,16 @@ fn member_address(member: logos_chat::GroupMember) -> String {
         .unwrap_or_default()
 }
 
-/// The roster of the group conversation `convo_id`, one member address per
-/// element (see [`member_address`]). This is a plain list with no error channel,
-/// mirroring `get_messages`: an unknown or non-group conversation, or a client
-/// error, yields an empty array (the client error is logged).
+/// One roster entry — mirrors the `GroupMember` record.
+#[derive(Serialize)]
+struct GroupMemberRow {
+    address: String,
+}
+
+/// The roster of the group conversation `convo_id`, one [`GroupMemberRow`] per
+/// element. This is a plain list with no error channel, mirroring `get_messages`:
+/// an unknown or non-group conversation, or a client error, yields an empty
+/// array (the client error is logged).
 pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
     let empty = || serde_json::Value::Array(vec![]);
     if !with_display(|d| d.state.chats.contains_key(convo_id)) {
@@ -436,8 +442,13 @@ pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
     }
     match with_client(|client| client.group_members(convo_id)) {
         Ok(Ok(members)) => {
-            let addrs: Vec<String> = members.into_iter().map(member_address).collect();
-            serde_json::to_value(addrs).unwrap_or_else(|_| empty())
+            let rows: Vec<GroupMemberRow> = members
+                .into_iter()
+                .map(|m| GroupMemberRow {
+                    address: member_address(m),
+                })
+                .collect();
+            serde_json::to_value(rows).unwrap_or_else(|_| empty())
         }
         Ok(Err(e)) => {
             eprintln!("chat_module: list_group_members failed: {e:?}");

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -20,11 +20,12 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crossbeam_channel::{Receiver, Sender};
-use logos_chat::Event;
+use logos_chat::{ConversationClass, Event};
 use logos_rust_sdk::{EventData, EventSubscription};
 
 use crate::actions::{record_conversation_started, record_message_received, set_delivery_state};
 use crate::module::{with_display, with_display_mut, DeliveryStateKind};
+use crate::persistence::ConversationKind;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -133,8 +134,8 @@ fn forward_subscriptions(subscribe_rx: &Receiver<String>) {
 fn run_events(events: Receiver<Event>) {
     for event in events {
         match event {
-            Event::ConversationStarted { convo_id, .. } => {
-                record_conversation_started(&convo_id);
+            Event::ConversationStarted { convo_id, class } => {
+                record_conversation_started(&convo_id, kind_for_class(class));
             }
             Event::MessageReceived {
                 convo_id,
@@ -152,6 +153,15 @@ fn run_events(events: Receiver<Event>) {
             // `Event` is `#[non_exhaustive]`; ignore variants added upstream.
             _ => {}
         }
+    }
+}
+
+/// Map libchat's display class to the module's contract kind: the pairwise
+/// shape (PrivateV1 / DirectV1) is `direct`, GroupV2 is `group`.
+fn kind_for_class(class: ConversationClass) -> ConversationKind {
+    match class {
+        ConversationClass::Private => ConversationKind::Direct,
+        ConversationClass::Group => ConversationKind::Group,
     }
 }
 
@@ -243,6 +253,18 @@ mod tests {
         assert_eq!(
             connection_transition(DeliveryStateKind::Error, "Connected"),
             Some(DeliveryStateKind::Online)
+        );
+    }
+
+    #[test]
+    fn class_maps_to_contract_kind() {
+        assert_eq!(
+            kind_for_class(ConversationClass::Private),
+            ConversationKind::Direct
+        );
+        assert_eq!(
+            kind_for_class(ConversationClass::Group),
+            ConversationKind::Group
         );
     }
 }

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -137,9 +137,14 @@ fn run_events(events: Receiver<Event>) {
                 record_conversation_started(&convo_id);
             }
             Event::MessageReceived {
-                convo_id, content, ..
+                convo_id,
+                content,
+                sender,
             } => {
-                record_message_received(&convo_id, &content);
+                // The account is directory-verified by the client; a sender
+                // that claims none surfaces as its device id.
+                let sender_addr = sender.account.as_ref().unwrap_or(&sender.local_identity);
+                record_message_received(&convo_id, &content, sender_addr.as_str());
             }
             Event::InboundError { message } => {
                 eprintln!("chat_module: inbound error: {message}");

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -19,9 +19,10 @@
 //!
 //! Return conventions. Status-bearing methods return `result`, surfaced here as
 //! `Result<serde_json::Value, String>`: `Ok(value)` carries any payload (a
-//! conversation id, an intro bundle, or `Null`), `Err(message)` a human-readable
-//! reason. Collection getters return `serde_json::Value` (a JSON array/object);
-//! `get_installation_name` returns a plain string, empty when not initialised.
+//! conversation id or `Null`), `Err(message)` a human-readable reason.
+//! Collection getters return `serde_json::Value` (a JSON array/object);
+//! `get_installation_name`/`get_address` return a plain string, empty when not
+//! initialised.
 //!
 //! Events reach consumers over the lp_* IPC channel: the operations below call
 //! the generated `emit_*` functions (see the included scaffold), which the host
@@ -127,18 +128,12 @@ impl ChatModule for ChatModuleImpl {
             .map_err(|e| e.to_string())
     }
 
-    fn create_intro_bundle(&mut self) -> Result<Value, String> {
-        actions::create_intro_bundle()
-            .map(Value::String)
-            .map_err(|e| e.to_string())
+    fn get_address(&mut self) -> String {
+        actions::get_address()
     }
 
-    fn create_conversation(
-        &mut self,
-        peer_intro_bundle: String,
-        initial_content: String,
-    ) -> Result<Value, String> {
-        actions::create_conversation(&peer_intro_bundle, &initial_content)
+    fn create_conversation(&mut self, peer_address: String) -> Result<Value, String> {
+        actions::create_conversation(&peer_address)
             .map(Value::String)
             .map_err(|e| e.to_string())
     }

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -138,6 +138,22 @@ impl ChatModule for ChatModuleImpl {
             .map_err(|e| e.to_string())
     }
 
+    fn create_group_conversation(&mut self) -> Result<Value, String> {
+        actions::create_group_conversation()
+            .map(Value::String)
+            .map_err(|e| e.to_string())
+    }
+
+    fn add_group_member(
+        &mut self,
+        convo_id: String,
+        peer_address: String,
+    ) -> Result<Value, String> {
+        actions::add_group_member(&convo_id, &peer_address)
+            .map(|()| Value::Null)
+            .map_err(|e| e.to_string())
+    }
+
     fn list_conversations(&mut self) -> Value {
         actions::list_conversations()
     }

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -162,6 +162,10 @@ impl ChatModule for ChatModuleImpl {
         actions::get_messages(&convo_id)
     }
 
+    fn list_group_members(&mut self, convo_id: String) -> Value {
+        actions::list_group_members(&convo_id)
+    }
+
     fn send_message(&mut self, convo_id: String, content: String) -> Result<Value, String> {
         actions::send_message(&convo_id, &content)
             .map(|()| Value::Null)

--- a/rust-lib/src/module.rs
+++ b/rust-lib/src/module.rs
@@ -25,17 +25,25 @@ use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use libchat::ChatStorage;
-use logos_chat::{ChatClient, DelegateSigner, EphemeralRegistry};
+use logos_chat::{ChatClient, HttpRegistry};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
 use crate::persistence::AppState;
 
-/// The chat client as this module configures it: a random delegate identity, the
-/// delivery_module-backed [`SdkDelivery`] transport, an in-process registry (only
-/// the intro-bundle path is used, which needs no shared registry), and a
-/// SQLCipher-backed store.
-pub(crate) type Client = ChatClient<DelegateSigner, SdkDelivery, EphemeralRegistry, ChatStorage>;
+/// The chat client as this module configures it: a delegate identity associated
+/// with an ephemeral account, the delivery_module-backed [`SdkDelivery`]
+/// transport, the devnet HTTP registry, and an in-memory store. Chats are
+/// ephemeral (see [`PERSISTENCE_ENABLED`]).
+pub(crate) type Client = ChatClient<SdkDelivery, HttpRegistry, ChatStorage>;
+
+/// Whether chat state persists across restarts. Off: identity, MLS/crypto state,
+/// and the display history are all ephemeral. DirectV1 has no reload path in
+/// libchat yet (a DirectV1 conversation's MLS state is never reloaded), so
+/// persisting would strand crypto state a restart can't resume. The persistence
+/// code (SQLCipher store, `history.json`) is kept behind this switch; flip it on
+/// once libchat can reload DirectV1 state.
+pub(crate) const PERSISTENCE_ENABLED: bool = false;
 
 // ── Delivery state ──────────────────────────────────────────────────────────
 
@@ -178,6 +186,10 @@ pub(crate) struct Display {
     /// libchat's intrinsic installation name, cached so `get_installation_name`
     /// needn't touch the client (which is behind the other lock).
     pub intrinsic_name: String,
+    /// The local installation address (libchat `ChatClient::addr`), cached so
+    /// `get_address` needn't touch the client. A peer needs this value to open a
+    /// DirectV1 conversation with this installation.
+    pub address: String,
 }
 
 impl Default for Display {
@@ -187,6 +199,7 @@ impl Default for Display {
             state_path: PathBuf::new(),
             delivery_state: DeliveryState::stopped(),
             intrinsic_name: String::new(),
+            address: String::new(),
         }
     }
 }

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -59,6 +59,26 @@ pub(crate) struct DisplayMessage {
     pub sender: Option<String>,
 }
 
+/// Whether a conversation is pairwise or a group; drives the members-panel
+/// affordance in the UI. Serialised as the contract's `"direct"`/`"group"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ConversationKind {
+    #[default]
+    Direct,
+    Group,
+}
+
+impl ConversationKind {
+    /// The contract wire string (`"direct"` / `"group"`).
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ConversationKind::Direct => "direct",
+            ConversationKind::Group => "group",
+        }
+    }
+}
+
 /// Per-conversation state held alongside libchat's cryptographic state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ChatSession {
@@ -66,6 +86,9 @@ pub(crate) struct ChatSession {
     pub chat_id: String,
     /// User-set display label. `None` falls back to `module::short_label`.
     pub nickname: Option<String>,
+    /// Pairwise vs group. `#[serde(default)]` reads pre-kind history as direct.
+    #[serde(default)]
+    pub kind: ConversationKind,
     /// Append-only render log of messages exchanged in this conversation.
     pub messages: Vec<DisplayMessage>,
 }
@@ -182,6 +205,8 @@ mod tests {
         let s = load_state(&p);
         assert_eq!(s.chats.len(), 1);
         assert!(s.chats.contains_key("abc"));
+        // A pre-kind record defaults to direct rather than failing the parse.
+        assert_eq!(s.chats["abc"].kind, ConversationKind::Direct);
         assert_eq!(s.installation_name, None);
         assert!(s.deleted.is_empty());
         let _ = fs::remove_dir_all(&dir);
@@ -244,6 +269,7 @@ mod tests {
             ChatSession {
                 chat_id: "convo".into(),
                 nickname: Some("bob".into()),
+                kind: ConversationKind::Group,
                 messages: vec![DisplayMessage {
                     from_self: true,
                     content: "hi".into(),
@@ -259,8 +285,24 @@ mod tests {
         assert_eq!(loaded.chats.len(), 1);
         let convo = &loaded.chats["convo"];
         assert_eq!(convo.nickname.as_deref(), Some("bob"));
+        assert_eq!(convo.kind, ConversationKind::Group);
         assert_eq!(convo.messages.len(), 1);
         assert_eq!(convo.messages[0].content, "hi");
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn conversation_kind_uses_contract_strings() {
+        assert_eq!(ConversationKind::Direct.as_str(), "direct");
+        assert_eq!(ConversationKind::Group.as_str(), "group");
+        // serde emits the same wire form `as_str` returns.
+        assert_eq!(
+            serde_json::to_value(ConversationKind::Group).unwrap(),
+            serde_json::json!("group")
+        );
+        assert_eq!(
+            serde_json::from_value::<ConversationKind>(serde_json::json!("direct")).unwrap(),
+            ConversationKind::Direct
+        );
     }
 }

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -54,6 +54,9 @@ pub(crate) struct DisplayMessage {
     /// Milliseconds since the Unix epoch when the message was recorded
     /// locally — not authoritative across peers.
     pub timestamp_ms: u64,
+    /// Sender's account address (device id if unassociated); `None` on
+    /// messages this installation sent.
+    pub sender: Option<String>,
 }
 
 /// Per-conversation state held alongside libchat's cryptographic state.
@@ -245,6 +248,7 @@ mod tests {
                     from_self: true,
                     content: "hi".into(),
                     timestamp_ms: 42,
+                    sender: None,
                 }],
             },
         );


### PR DESCRIPTION
The UI cannot tell a direct chat from a group, nor show a group's
membership: the Conversation record and conversation_created event
carried no direct/group discriminator, and no method exposed a group's
roster. Both are needed to render a members panel for groups only and to
list who is in a group.

- Contract 0.2.0 -> 0.3.0 (lidl, metadata.json, crate version):
  Conversation and conversation_created gain a `kind` field
  ("direct"/"group"); new list_group_members(convo_id) -> [tstr] returns
  a group's roster, each member as its directory-verified account
  address or device id (the same convention `sender` uses).
- ChatSession gains a `kind` field (serde direct/group, defaulting to
  direct for pre-kind history). create_conversation records direct,
  create_group_conversation records group, and record_conversation_started
  classes an inbound conversation from libchat's ConversationClass
  (Private -> direct, Group -> group), which run_events now forwards
  instead of discarding.
- list_group_members reads the roster via ChatClient::group_members; an
  unknown or non-group conversation yields an empty list, mirroring
  get_messages (a plain list method with no error channel).
- Re-pin the three libchat crates to the feat/groupv2-roster rev, which
  adds group_members and the honest DirectV1 display class. de-mls stays
  at libchat's locked rev.
- The group doctest asserts the three-member roster via
  list_group_members; the README documents kind and list_group_members.

---

PR note: stacks on #43 (feat/groupv2). Pins libchat to feat/groupv2-roster (#165, unmerged); the three libchat crates and the lock carry rev 89afa0b. Drop the rev pin to a version/branch once #165 lands. CI needs #165's branch present (it is) to resolve the libchat git dep.
