### PR TITLE
feat: surface group roster changes as a members_changed event

### DIFF
--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "crypto",
  "hex",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "base64",
  "crossbeam-channel",
@@ -1479,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?branch=main#2b3eed17723d4fb12037ef8cfb1f5e8c115b09a1"
+source = "git+https://github.com/vacp2p/de-mls?rev=2c7a8669c1492c749c02efd2c5ac45e93e4926a3#2c7a8669c1492c749c02efd2c5ac45e93e4926a3"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "hashgraph-like-consensus"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b6328e1ba3b6ff66e24a018b40c6ea61a3105607755ac378003b57de7bc19d"
+checksum = "cba53b85cc33f28262bbd9c258bbbf3f3b66501ef7cc2b7137712215fdf7cbf5"
 dependencies = [
  "alloy",
  "alloy-signer",
@@ -2891,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3228,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "logos-generic-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=e7e122b0cc3f696e38d82be0f883ac74cae157d8#e7e122b0cc3f696e38d82be0f883ac74cae157d8"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -25,19 +25,21 @@ panic = "abort"
 # observations as `Event`s on a channel the module drains. The module brings its own
 # delivery (logoscore's delivery_module), so it depends on this transport-generic
 # crate, not the `logos-chat` facade that bundles an embedded logos delivery.
-# rev-pinned to libchat main at the merged GroupV2 rev (#167): the group ops this
-# module needs (create_group_conversation / add_group_members, injectable GroupV2
-# timing, the `group_members` roster, and the honest DirectV1 display class) are on
-# main but not in a released libchat version yet.
-logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "e7e122b0cc3f696e38d82be0f883ac74cae157d8" }
+# rev-pinned to libchat's roster-changed-event work on origin/main: it adds
+# Event::ConversationMembersChanged, which this module surfaces as the
+# `members_changed` contract event, on top of the GroupV2 group ops the module
+# needs (create_group_conversation / add_group_members, the `group_members`
+# roster, injectable GroupV2 timing, the honest DirectV1 display class). Not yet
+# in a released libchat version.
+logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "e7e122b0cc3f696e38d82be0f883ac74cae157d8" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "e7e122b0cc3f696e38d82be0f883ac74cae157d8" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -85,6 +85,7 @@ module chat_module {
   ; kind: "direct" (1:1) or "group", matching the Conversation record's field.
   event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr, kind: tstr)
   event conversation_updated(convo_id: tstr)
+  event members_changed(convo_id: tstr)
   event conversation_deleted(convo_id: tstr)
   event delivery_state_changed(delivery_state: tstr, detail: tstr)
 }

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -647,6 +647,19 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
     });
 }
 
+/// Surface a group roster change (the client's `ConversationMembersChanged`
+/// event). No-op for a locally-deleted or unknown conversation. Called from the
+/// event consumer thread; takes only the display lock, so it never waits on the
+/// client.
+pub(crate) fn record_members_changed(convo_id: &str) {
+    with_display(|d| {
+        if d.state.deleted.contains(convo_id) || !d.state.chats.contains_key(convo_id) {
+            return;
+        }
+        crate::emit_members_changed(convo_id);
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::member_address;

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -23,7 +23,10 @@ use crossbeam_channel::{Receiver, Sender};
 use logos_generic_chat::{ConversationClass, Event};
 use logos_rust_sdk::{EventData, EventSubscription};
 
-use crate::actions::{record_conversation_started, record_message_received, set_delivery_state};
+use crate::actions::{
+    record_conversation_started, record_members_changed, record_message_received,
+    set_delivery_state,
+};
 use crate::module::{with_display, with_display_mut, DeliveryStateKind};
 use crate::persistence::ConversationKind;
 
@@ -146,6 +149,9 @@ fn run_events(events: Receiver<Event>) {
                 // that claims none surfaces as its device id.
                 let sender_addr = sender.account.as_ref().unwrap_or(&sender.local_identity);
                 record_message_received(&convo_id, &content, sender_addr.as_str());
+            }
+            Event::ConversationMembersChanged { convo_id } => {
+                record_members_changed(&convo_id);
             }
             Event::InboundError { message } => {
                 eprintln!("chat_module: inbound error: {message}");


### PR DESCRIPTION
A group's roster changed with no signal to the UI: add_group_member emitted conversation_updated only on the local actor, and nothing fired when a member actually joined ~a commit later, so the roster refreshed only on manual refresh, re-selecting the conversation, or a message from the new member.

libchat now reports the change (Event::ConversationMembersChanged, fired on every member a commit reaches). Drain it and re-emit a dedicated contract event the UI subscribes to.

- Bump the libchat pins (logos-generic-chat, libchat, logos-account) to the rev that adds the event; this also pulls in the GroupV2 time-source/timing injection (#168) and group description (#161) already on main.
- New members_changed(convo_id) event in chat_module.lidl. Distinct from conversation_updated (metadata) so the UI re-fetches only the roster.
- run_events handles the new Event variant via record_members_changed, which emits for a known, non-deleted conversation.

---
Builds on the libchat roster event (logos-messaging/libchat#177, merged), pinned by rev. Consumed by logos-co/logos-chat-ui#33.
