### PR TITLE
feat: surface a group's shared name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,17 @@ reason. Collection getters (`list_conversations`, `get_messages`) return JSON
 arrays. See the `.lidl` for the full method list and record shapes.
 
 Two conversation shapes are exposed. `create_conversation(peer_address)` opens
-a 1:1 DirectV1 conversation. `create_group_conversation()` creates a GroupV2
-(de-mls) group with this installation as its only member, grown one peer at a
-time with `add_group_member(convo_id, peer_address)`; every member sees the
-same conversation id, and adds are committed by the group's steward
-asynchronously, so a peer joins some time after the call returns.
+a 1:1 DirectV1 conversation. `create_group_conversation(name, desc)` creates a
+GroupV2 (de-mls) group with this installation as its only member, grown one
+peer at a time with `add_group_member(convo_id, peer_address)`; every member
+sees the same conversation id, and adds are committed by the group's steward
+asynchronously, so a peer joins some time after the call returns. A group's
+`name` and `desc` are shared metadata carried to every joiner, both optional.
 `list_group_members(convo_id)` returns a group's roster from libchat's MLS
 state. The `Conversation` record and the `conversation_created` event carry a
-`kind` (`"direct"` or `"group"`) distinguishing the two shapes. Received
+`kind` (`"direct"` or `"group"`) distinguishing the two shapes, plus a group's
+shared `name` and `description` (unset for direct conversations and unnamed
+groups). Received
 messages carry a `sender` (on the `Message` record and the `message_received`
 event): the sender's directory-verified account address, or its device id
 when the sender claims no account.
@@ -73,7 +76,7 @@ positional arguments in `.lidl` order:
 - **`message_sent`** — an outbound message was recorded
   - `convo_id` (`tstr`), `content` (`tstr`), `timestamp_ms` (`int`)
 - **`conversation_created`** — a conversation was opened
-  - `convo_id` (`tstr`), `is_outgoing` (`bool`), `peer_label` (`tstr`), `kind` (`tstr`)
+  - `convo_id` (`tstr`), `is_outgoing` (`bool`), `peer_label` (`tstr`), `kind` (`tstr`), `name` (`tstr`), `desc` (`tstr`)
 - **`conversation_updated`** — a conversation's metadata changed
   - `convo_id` (`tstr`)
 - **`conversation_deleted`** — a conversation was removed

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -30,7 +30,7 @@ what_you_build: "A verified three-member, end-to-end-encrypted group conversatio
 
 what_you_learn:
   - "Run three isolated `logoscore` daemons on one host, selected by `--config-dir`"
-  - "Create a group with `create_group_conversation()` and grow it with `add_group_member` — including an add proposed by a non-creator member"
+  - "Create a named group with `create_group_conversation` and grow it with `add_group_member` — including an add proposed by a non-creator member"
   - "Why a group join lands asynchronously (consensus + steward commit + welcome), and how to observe it by polling `list_conversations`"
   - "How every member shares one conversation id, and how `get_messages` attributes each inbound message to its sender's account address"
 
@@ -230,19 +230,21 @@ sections:
           key material behind it was published to the registry during `init`.
       - title: "Alice creates the group"
         run: |
-          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_group_conversation)
+          out=$(./logos/bin/logoscore --config-dir alice call chat_module create_group_conversation "Book Club" "Weekly sci-fi picks")
           echo "$out"
           echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "create_group_conversation failed: $out" >&2; exit 1; }
           echo "$out" | jq -j '.result.value' > group-id.txt
           echo "group id: $(cat group-id.txt)"
         code_block: |
-          logoscore --config-dir alice call chat_module create_group_conversation
+          logoscore --config-dir alice call chat_module create_group_conversation "Book Club" "Weekly sci-fi picks"
         expect_contains:
           - '"status":"ok"'
           - "group id:"
         post_text: |
           The group starts with Alice as its only member; `result.value` is the
-          conversation id **every** member will see once they join.
+          conversation id **every** member will see once they join. The name and
+          description Alice passed are the group's shared metadata, stored in its
+          MLS context and delivered to every joiner in the welcome.
       - title: "Alice invites Bob"
         run: |
           gid=$(cat group-id.txt)
@@ -257,23 +259,24 @@ sections:
         post_text: |
           The call returns as soon as the add is proposed; the commit and the
           welcome happen asynchronously in the group.
-      - title: "Bob joins"
+      - title: "Bob joins and sees the shared name"
         run: |
           gid=$(cat group-id.txt)
           for i in $(seq 1 150); do
-            got=$(./logos/bin/logoscore --config-dir bob call chat_module list_conversations 2>/dev/null | jq -r --arg id "$gid" '.result[]? | select(.convo_id == $id) | .convo_id' || true)
-            if [ -n "$got" ]; then echo "BOB_IN_GROUP $got"; break; fi
+            row=$(./logos/bin/logoscore --config-dir bob call chat_module list_conversations 2>/dev/null | jq -c --arg id "$gid" '.result[]? | select(.convo_id == $id)' || true)
+            if [ -n "$row" ]; then echo "BOB_IN_GROUP name=$(echo "$row" | jq -r '.name // ""')"; break; fi
             sleep 4
           done
-          [ -n "$got" ] || { echo "bob never joined the group" >&2; tail -n 40 bob-daemon.log >&2; exit 1; }
+          [ -n "$row" ] || { echo "bob never joined the group" >&2; tail -n 40 bob-daemon.log >&2; exit 1; }
         code_block: |
-          # poll until the group id appears in Bob's conversations
+          # poll until the group appears in Bob's conversations, carrying its name
           logoscore --config-dir bob call chat_module list_conversations
         expect_contains:
-          - "BOB_IN_GROUP"
+          - "BOB_IN_GROUP name=Book Club"
         post_text: |
           Bob's instance observes the group under the **same** conversation id
-          Alice created — one id per group, shared by all members.
+          Alice created, and its shared name reached him in the welcome: no local
+          argument set it. One id and one name per group, shared by all members.
       - title: "Bob invites Carol (a non-creator add)"
         run: |
           gid=$(cat group-id.txt)

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "crypto",
  "hex",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "base64",
  "crossbeam-channel",
@@ -1479,7 +1479,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2891,7 +2891,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3228,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "logos-generic-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4950,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=b0de5321997402357e3cb6bc47f6f3fd4ca33818#b0de5321997402357e3cb6bc47f6f3fd4ca33818"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -25,21 +25,22 @@ panic = "abort"
 # observations as `Event`s on a channel the module drains. The module brings its own
 # delivery (logoscore's delivery_module), so it depends on this transport-generic
 # crate, not the `logos-chat` facade that bundles an embedded logos delivery.
-# rev-pinned to libchat's roster-changed-event work on origin/main: it adds
-# Event::ConversationMembersChanged, which this module surfaces as the
-# `members_changed` contract event, on top of the GroupV2 group ops the module
-# needs (create_group_conversation / add_group_members, the `group_members`
-# roster, injectable GroupV2 timing, the honest DirectV1 display class). Not yet
-# in a released libchat version.
-logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
+# rev-pinned to libchat's unreleased group name/description client surface: it
+# adds a name and description to create_group_conversation and a group_metadata
+# getter, which this module stores and surfaces as each conversation's name and
+# description, on top of the GroupV2 group ops it already needs (add_group_members,
+# the `group_members` roster, the Event::ConversationMembersChanged behind the
+# `members_changed` contract event, injectable GroupV2 timing, the honest DirectV1
+# display class). Not yet in a released libchat version.
+logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "b0de5321997402357e3cb6bc47f6f3fd4ca33818" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -23,6 +23,11 @@ module chat_module {
     last_activity_ms: int
     ; "direct" (1:1) or "group". PrivateV1 and DirectV1 are both "direct".
     kind: tstr
+    ; A group's shared name and description (set at creation, identical for
+    ; every member). Absent for direct conversations and unnamed groups;
+    ; distinct from the local-only `nickname`.
+    ? name: tstr
+    ? description: tstr
   }
   type Message {
     from_self: bool
@@ -60,7 +65,9 @@ module chat_module {
   method create_conversation(peer_address: tstr) -> result
   ; Create a group conversation with this installation as its only member;
   ; grow it with add_group_member. Every member sees the returned convo_id.
-  method create_group_conversation() -> result
+  ; name and desc are the group's shared metadata, visible to every member;
+  ; both may be empty for an unnamed group.
+  method create_group_conversation(name: tstr, desc: tstr) -> result
   ; Invite the peer at peer_address into an existing group conversation. The
   ; invite is committed and delivered asynchronously; the peer observes the
   ; conversation once its instance has joined.
@@ -83,7 +90,9 @@ module chat_module {
   event message_received(convo_id: tstr, content: tstr, timestamp_ms: int, sender: tstr)
   event message_sent(convo_id: tstr, content: tstr, timestamp_ms: int)
   ; kind: "direct" (1:1) or "group", matching the Conversation record's field.
-  event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr, kind: tstr)
+  ; name, desc: the group's shared metadata, empty for direct conversations and
+  ; unnamed groups.
+  event conversation_created(convo_id: tstr, is_outgoing: bool, peer_label: tstr, kind: tstr, name: tstr, desc: tstr)
   event conversation_updated(convo_id: tstr)
   event members_changed(convo_id: tstr)
   event conversation_deleted(convo_id: tstr)

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use libchat::ChatStorage;
 use logos_account::TestLogosAccount;
-use logos_generic_chat::{ChatClientBuilder, DelegateSigner, HttpRegistry, StorageConfig};
+use logos_generic_chat::{
+    ChatClientBuilder, DelegateSigner, GroupMetadata, HttpRegistry, StorageConfig,
+};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
@@ -69,6 +71,8 @@ struct ConversationSummary {
     message_count: usize,
     last_activity_ms: u64,
     kind: ConversationKind,
+    name: Option<String>,
+    description: Option<String>,
 }
 
 /// `status` payload — mirrors the `Status` record.
@@ -299,6 +303,16 @@ fn persist(d: &Display) -> Result<(), CoreError> {
     save_display(d).map_err(|e| CoreError::Internal(format!("save_state failed: {e}")))
 }
 
+/// `None` for an empty string, the empty-means-unset convention shared with
+/// nicknames and a group's optional name/description.
+fn non_empty(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
 /// Persist the display state, unless persistence is disabled (ephemeral mode),
 /// in which case this is a no-op reporting success. See
 /// [`module::PERSISTENCE_ENABLED`](crate::module::PERSISTENCE_ENABLED).
@@ -364,6 +378,8 @@ pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreErro
                 chat_id: chat_id.clone(),
                 nickname: None,
                 kind: ConversationKind::Direct,
+                name: None,
+                description: None,
                 messages: Vec::new(),
             },
         );
@@ -374,17 +390,22 @@ pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreErro
         true,
         &peer_label,
         ConversationKind::Direct.as_str(),
+        "",
+        "",
     );
 
     Ok(chat_id)
 }
 
 /// Create a GroupV2 conversation with this installation as its only member;
-/// peers are invited afterwards via [`add_group_member`]. Returns the
-/// conversation id, which every member observes once joined.
-pub(crate) fn create_group_conversation() -> Result<String, CoreError> {
-    let chat_id = with_client(|client| client.create_group_conversation(&[]))?
-        .map_err(|e| CoreError::Internal(format!("create_group_conversation failed: {e:?}")))?;
+/// peers are invited afterwards via [`add_group_member`]. `name` and `desc` are
+/// the group's shared metadata, carried to every joiner; both may be empty.
+/// Returns the conversation id, which every member observes once joined.
+pub(crate) fn create_group_conversation(name: &str, desc: &str) -> Result<String, CoreError> {
+    let chat_id = with_client(|client| {
+        client.create_group_conversation(&[], GroupMetadata::new(name, desc))
+    })?
+    .map_err(|e| CoreError::Internal(format!("create_group_conversation failed: {e:?}")))?;
 
     let label = short_label(&chat_id).to_owned();
     with_display_mut(|d| {
@@ -394,12 +415,21 @@ pub(crate) fn create_group_conversation() -> Result<String, CoreError> {
                 chat_id: chat_id.clone(),
                 nickname: None,
                 kind: ConversationKind::Group,
+                name: non_empty(name),
+                description: non_empty(desc),
                 messages: Vec::new(),
             },
         );
         persist(d)
     })?;
-    crate::emit_conversation_created(&chat_id, true, &label, ConversationKind::Group.as_str());
+    crate::emit_conversation_created(
+        &chat_id,
+        true,
+        &label,
+        ConversationKind::Group.as_str(),
+        name,
+        desc,
+    );
 
     Ok(chat_id)
 }
@@ -478,6 +508,8 @@ pub(crate) fn list_conversations() -> serde_json::Value {
                 message_count: s.messages.len(),
                 last_activity_ms: s.messages.last().map(|m| m.timestamp_ms).unwrap_or(0),
                 kind: s.kind,
+                name: s.name.clone(),
+                description: s.description.clone(),
             })
             .collect();
         serde_json::to_value(items).unwrap_or_else(|_| serde_json::Value::Array(vec![]))
@@ -582,9 +614,28 @@ pub(crate) fn set_delivery_state(d: &mut Display, state: DeliveryStateKind, deta
 
 /// Record a newly-observed conversation (the client's `ConversationStarted`
 /// event) and surface it, classed by `kind`. No-op for a locally-deleted or
-/// already-known conversation. Called from the event consumer thread; takes only
-/// the display lock, so it never waits on the client.
+/// already-known conversation. Called from the event consumer thread; a group
+/// first reads its shared metadata under the client lock, then records under the
+/// display lock (the two are never held at once).
 pub(crate) fn record_conversation_started(convo_id: &str, kind: ConversationKind) {
+    // A joiner learns a group's name and description from the client, not from a
+    // local argument; a direct conversation carries none. Read it before taking
+    // the display lock so the client and display locks are never nested.
+    let (name, description) = if kind == ConversationKind::Group {
+        match with_client(|client| client.group_metadata(convo_id)) {
+            Ok(Ok(meta)) => (non_empty(&meta.name), non_empty(&meta.desc)),
+            Ok(Err(e)) => {
+                eprintln!("chat_module: group_metadata failed: {e:?}");
+                (None, None)
+            }
+            Err(e) => {
+                eprintln!("chat_module: group_metadata: {e}");
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
     with_display_mut(|d| {
         // libchat retains crypto state across local deletes, so we still observe
         // events for deleted convos.
@@ -597,10 +648,19 @@ pub(crate) fn record_conversation_started(convo_id: &str, kind: ConversationKind
                 chat_id: convo_id.to_owned(),
                 nickname: None,
                 kind,
+                name: name.clone(),
+                description: description.clone(),
                 messages: Vec::new(),
             },
         );
-        crate::emit_conversation_created(convo_id, false, short_label(convo_id), kind.as_str());
+        crate::emit_conversation_created(
+            convo_id,
+            false,
+            short_label(convo_id),
+            kind.as_str(),
+            name.as_deref().unwrap_or(""),
+            description.as_deref().unwrap_or(""),
+        );
 
         // Event consumer has no caller to return to; log a failed write.
         if let Err(e) = save_display(d) {
@@ -629,8 +689,11 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
                 chat_id: convo_id.to_owned(),
                 nickname: None,
                 // Defensive fallback: ConversationStarted normally creates the
-                // session with the real kind before any message lands here.
+                // session with the real kind and metadata before any message
+                // lands here.
                 kind: ConversationKind::default(),
+                name: None,
+                description: None,
                 messages: Vec::new(),
             });
         session.messages.push(DisplayMessage {

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -138,8 +138,8 @@ impl ChatModule for ChatModuleImpl {
             .map_err(|e| e.to_string())
     }
 
-    fn create_group_conversation(&mut self) -> Result<Value, String> {
-        actions::create_group_conversation()
+    fn create_group_conversation(&mut self, name: String, desc: String) -> Result<Value, String> {
+        actions::create_group_conversation(&name, &desc)
             .map(Value::String)
             .map_err(|e| e.to_string())
     }

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -89,6 +89,12 @@ pub(crate) struct ChatSession {
     /// Pairwise vs group. `#[serde(default)]` reads pre-kind history as direct.
     #[serde(default)]
     pub kind: ConversationKind,
+    /// Group's shared name, `None` for a direct conversation or unnamed group.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Group's shared description, `None` when unset.
+    #[serde(default)]
+    pub description: Option<String>,
     /// Append-only render log of messages exchanged in this conversation.
     pub messages: Vec<DisplayMessage>,
 }
@@ -207,6 +213,9 @@ mod tests {
         assert!(s.chats.contains_key("abc"));
         // A pre-kind record defaults to direct rather than failing the parse.
         assert_eq!(s.chats["abc"].kind, ConversationKind::Direct);
+        // A pre-metadata record defaults its name and description to unset.
+        assert_eq!(s.chats["abc"].name, None);
+        assert_eq!(s.chats["abc"].description, None);
         assert_eq!(s.installation_name, None);
         assert!(s.deleted.is_empty());
         let _ = fs::remove_dir_all(&dir);
@@ -270,6 +279,8 @@ mod tests {
                 chat_id: "convo".into(),
                 nickname: Some("bob".into()),
                 kind: ConversationKind::Group,
+                name: Some("Book Club".into()),
+                description: Some("Weekly reads".into()),
                 messages: vec![DisplayMessage {
                     from_self: true,
                     content: "hi".into(),
@@ -286,6 +297,8 @@ mod tests {
         let convo = &loaded.chats["convo"];
         assert_eq!(convo.nickname.as_deref(), Some("bob"));
         assert_eq!(convo.kind, ConversationKind::Group);
+        assert_eq!(convo.name.as_deref(), Some("Book Club"));
+        assert_eq!(convo.description.as_deref(), Some("Weekly reads"));
         assert_eq!(convo.messages.len(), 1);
         assert_eq!(convo.messages[0].content, "hi");
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
A group now carries a shared name and description. create_group_conversation takes both and stores them at creation; a joiner reads them from the client (group_metadata) when its conversation starts. They live in the persisted ChatSession and are surfaced on the Conversation record, on list_conversations, and on the conversation_created event (empty when absent), so the metadata arrives with the event without a re-list and survives a restart the same way messages do.

The libchat pin moves to the commit that adds this metadata to the threaded client. The contract gains name and desc on create_group_conversation, name and description on the Conversation record, and two trailing fields on conversation_created, without a version bump, because 0.2.0 is unreleased. Existing persisted state keeps loading: the new ChatSession fields default to unset.


---

Note (not part of the commit): the libchat pin is on the unmerged head of logos-messaging/libchat#183. Re-pin to the squash-merge commit once that PR lands, folding it into the pin commit, and drop this note.
