### PR TITLE
feat: add a message preview to conversation summaries

### DIFF
--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -28,6 +28,9 @@ module chat_module {
     ; distinct from the local-only `nickname`.
     ? name: tstr
     ? description: tstr
+    ; The last message's content, truncated to 160 characters, for a
+    ; conversation-list preview. Absent when the conversation has no messages.
+    ? preview: tstr
   }
   type Message {
     from_self: bool

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -63,6 +63,10 @@ pub(crate) enum InitError {
 // messages list reuses `persistence::DisplayMessage`, which already matches the
 // `Message` record.
 
+/// Character cap for a conversation-list preview. Mirrored on the UI so live and
+/// rehydrated previews agree.
+const PREVIEW_MAX_CHARS: usize = 160;
+
 /// One element of `list_conversations` — mirrors the `Conversation` record.
 #[derive(Serialize)]
 struct ConversationSummary {
@@ -73,6 +77,7 @@ struct ConversationSummary {
     kind: ConversationKind,
     name: Option<String>,
     description: Option<String>,
+    preview: Option<String>,
 }
 
 /// `status` payload — mirrors the `Status` record.
@@ -510,6 +515,10 @@ pub(crate) fn list_conversations() -> serde_json::Value {
                 kind: s.kind,
                 name: s.name.clone(),
                 description: s.description.clone(),
+                preview: s
+                    .messages
+                    .last()
+                    .map(|m| m.content.chars().take(PREVIEW_MAX_CHARS).collect()),
             })
             .collect();
         serde_json::to_value(items).unwrap_or_else(|_| serde_json::Value::Array(vec![]))


### PR DESCRIPTION
Each conversation summary now carries the last message's content, truncated to 160 characters on a character boundary and absent when the conversation has no messages, so a conversation list can show a preview without fetching every message log.

The field lands under the unreleased 0.2.0 contract, so it adds no version bump.

Based on `feat/group-metadata` (#48), now merged; rebased onto `master`. The chat-ui `feat/ux-polish` branch consumes this field on its rehydrate path.
