### PR TITLE
feat: install a tracing subscriber so libchat's logs are visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Bring-up is `init(instance_path, delivery_preset, tcp_port)` (empty preset →
 `logos.dev`). `init` starts delivery asynchronously and returns immediately;
 readiness arrives later as a `delivery_state_changed` event reaching `online`.
 
+`init` also installs a `tracing` subscriber, so libchat's log events go to the
+module's stderr and the host forwards them into its own log. The default level
+is `warn`; `RUST_LOG`, read from the environment the module process inherits
+from its host, selects more. libchat logs under two targets: `libchat` (the
+conversation core, MLS groups, inbox) and `logos_generic_chat` (the threaded
+client and its inbound worker), so a verbose run is
+`RUST_LOG=warn,libchat=debug,logos_generic_chat=debug`.
+
 ## Doc-tests
 
 The specs under [`doctests/`](doctests/) are executable usage tutorials: each

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing-subscriber",
  "xeddsa",
 ]
 
@@ -2877,6 +2878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,6 +3297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,6 +3327,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -4861,6 +4886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-traits"
 version = "0.1.0"
 source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
@@ -5080,6 +5114,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -5333,6 +5376,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -55,6 +55,8 @@ thiserror      = "2"
 # Hex-encodes the account verifying key as this installation's shared address,
 # and the delegate device key into the account's signed device bundle.
 hex            = "0.4"
+# The process's `tracing` subscriber (see `logging`); `env-filter` reads `RUST_LOG`.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -34,6 +34,7 @@
 mod actions;
 mod delivery;
 mod inbound;
+mod logging;
 mod module;
 mod panic_hook;
 mod persistence;
@@ -77,6 +78,7 @@ impl ChatModule for ChatModuleImpl {
         tcp_port: i64,
     ) -> Result<Value, String> {
         panic_hook::install_once();
+        logging::install_once();
 
         let preset = if delivery_preset.is_empty() {
             "logos.dev"

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -1,0 +1,27 @@
+//! `tracing` subscriber installed on first init.
+//!
+//! libchat logs exclusively through `tracing`, and a `tracing` event emitted in
+//! a process with no subscriber installed is dropped. Install one writing to
+//! stderr, where the module's own diagnostics already go, so the chat stack's
+//! own account of a failure is available next to them.
+
+use std::sync::Once;
+
+use tracing_subscriber::EnvFilter;
+
+static INSTALL: Once = Once::new();
+
+/// Routes `tracing` events to stderr at the level `RUST_LOG` selects, `warn`
+/// when it is unset or unparseable.
+pub(crate) fn install_once() {
+    INSTALL.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+        // The output lands in pipes and rotating log files, where ANSI escapes
+        // are noise. `try_init` leaves an already-installed subscriber alone.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .with_ansi(false)
+            .try_init();
+    });
+}


### PR DESCRIPTION
libchat logs exclusively through `tracing`, and an event emitted in a process with no subscriber installed is dropped, so nothing the chat stack logged from inside the module process ever reached the host's log.

The default level is `warn` rather than `off`, following chat-cli: quiet in normal operation, while the warnings and errors that motivated this surface without setting anything.

