### PR TITLE
feat: store instance state under the host-assigned persistence path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,12 @@ End-to-end chat needs a `delivery_module` available to the host at runtime; the
 flake pins [`logos-delivery-module`](https://github.com/logos-co/logos-delivery-module)
 at `v0.1.2`. Load `chat_module` via `logoscore` or Basecamp.
 
-Bring-up is `init(instance_path, delivery_preset, tcp_port)` (empty preset →
-`logos.dev`). `init` starts delivery asynchronously and returns immediately;
-readiness arrives later as a `delivery_state_changed` event reaching `online`.
+Bring-up is `init(delivery_preset, tcp_port)` (empty preset → `logos.dev`).
+`init` starts delivery asynchronously and returns immediately; readiness arrives
+later as a `delivery_state_changed` event reaching `online`. State is written to
+the instance directory the host assigns, so running two instances side by side
+is a matter of giving each host its own session directory (`--config-dir` under
+`logoscore`); `init` fails when the host assigned no such directory.
 
 ## Doc-tests
 

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -107,10 +107,11 @@ sections:
       **separate daemons**. The only thing that keeps them apart is `--config-dir`:
       it scopes each daemon's control socket, client token, and persistence to its
       own tree, so a `logoscore call --config-dir alice ...` always reaches Alice's
-      daemon. (Their delivery nodes are kept apart separately, by the distinct
-      `tcp_port` passed to `init` in the next step.)
+      daemon. That is also what isolates the two `chat_module` instances on disk:
+      the daemon assigns each module instance a directory under its config dir,
+      and the module stores everything there. (Their delivery nodes are kept apart
+      separately, by the distinct `tcp_port` passed to `init` in the next step.)
     steps:
-      - run: "mkdir -p alice-data bob-data"
       - title: "Start Alice's daemon"
         run: "sh -c './logos/bin/logoscore --config-dir alice -D -m ./modules > alice-daemon.log 2>&1 &'"
         code_block: "logoscore --config-dir alice -D -m ./modules > alice-daemon.log &"
@@ -150,26 +151,27 @@ sections:
   - title: "Bring both instances online"
     step: true
     text: |
-      `init(instance_path, delivery_preset, tcp_port)` returns immediately and
-      kicks off the delivery bootstrap asynchronously; readiness arrives later when
-      the subscribe handshake completes and `status().delivery_state` flips to
+      `init(delivery_preset, tcp_port)` returns immediately and kicks off the
+      delivery bootstrap asynchronously; readiness arrives later when the
+      subscribe handshake completes and `status().delivery_state` flips to
       `online`. Both instances are initialised **first** so their two cold Waku
       bootstraps overlap, then each is polled; the wait is ~the slower of the two,
       not their sum.
     steps:
       - title: "Initialise Alice (delivery port 60010) and Bob (60011)"
         run: |
-          ./logos/bin/logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60010
-          ./logos/bin/logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60011
+          ./logos/bin/logoscore --config-dir alice call chat_module init logos.test 60010
+          ./logos/bin/logoscore --config-dir bob   call chat_module init logos.test 60011
         code_block: |
-          logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60010
-          logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60011
+          logoscore --config-dir alice call chat_module init logos.test 60010
+          logoscore --config-dir bob   call chat_module init logos.test 60011
         expect_contains:
           - '"status":"ok"'
         post_text: |
-          Distinct `instance_path` and `tcp_port` per instance: `tcp_port` is bound
-          for both the Waku TCP listener and the discv5 UDP port, so the two nodes
-          must not share it.
+          A distinct `tcp_port` per instance: it is bound for both the Waku TCP
+          listener and the discv5 UDP port, so the two nodes must not share it.
+          Storage needs no argument: each instance uses the directory its daemon
+          assigned it.
       - title: "Wait for both to reach Online"
         run: |
           for who in alice bob; do

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -99,10 +99,10 @@ sections:
     text: |
       One module is a per-host singleton inside a daemon, so Alice, Bob, and
       Carol are **separate daemons**, kept apart by `--config-dir` (control
-      socket, client token, persistence) and, in the next step, by distinct
+      socket, client token, persistence, and the per-instance directory each daemon
+      assigns its `chat_module`) and, in the next step, by distinct
       `tcp_port`s for their delivery nodes.
     steps:
-      - run: "mkdir -p alice-data bob-data carol-data"
       - title: "Start the three daemons"
         run: |
           sh -c './logos/bin/logoscore --config-dir alice -D -m ./modules > alice-daemon.log 2>&1 &'
@@ -148,9 +148,9 @@ sections:
   - title: "Bring the three instances online"
     step: true
     text: |
-      `init(instance_path, delivery_preset, tcp_port)` returns immediately and
-      kicks off the delivery bootstrap asynchronously; readiness arrives later
-      when `status().delivery_state` flips to `online`. All three are
+      `init(delivery_preset, tcp_port)` returns immediately and kicks off the
+      delivery bootstrap asynchronously; readiness arrives later when
+      `status().delivery_state` flips to `online`. All three are
       initialised **first** so their cold Waku bootstraps overlap, then each is
       polled; the wait is ~the slowest of the three, not their sum.
     steps:
@@ -158,23 +158,24 @@ sections:
         run: |
           for who in alice bob carol; do
             case "$who" in alice) port=60020;; bob) port=60021;; carol) port=60022;; esac
-            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init "$PWD/${who}-data" logos.test "$port")
+            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init logos.test "$port")
             echo "$out"
             echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "$who init failed: $out" >&2; exit 1; }
             echo "${who}_INIT_OK"
           done
         code_block: |
-          logoscore --config-dir alice call chat_module init "$PWD/alice-data" logos.test 60020
-          logoscore --config-dir bob   call chat_module init "$PWD/bob-data"   logos.test 60021
-          logoscore --config-dir carol call chat_module init "$PWD/carol-data" logos.test 60022
+          logoscore --config-dir alice call chat_module init logos.test 60020
+          logoscore --config-dir bob   call chat_module init logos.test 60021
+          logoscore --config-dir carol call chat_module init logos.test 60022
         expect_contains:
           - "alice_INIT_OK"
           - "bob_INIT_OK"
           - "carol_INIT_OK"
         post_text: |
-          Distinct `instance_path` and `tcp_port` per instance: `tcp_port` is
-          bound for both the Waku TCP listener and the discv5 UDP port, so no
-          two nodes may share one.
+          A distinct `tcp_port` per instance: it is bound for both the Waku TCP
+          listener and the discv5 UDP port, so no two nodes may share one.
+          Storage needs no argument: each instance uses the directory its daemon
+          assigned it.
       - title: "Wait for all three to reach Online"
         run: |
           for who in alice bob carol; do

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -52,7 +52,9 @@ module chat_module {
   }
 
   ; --- lifecycle ---
-  method init(instance_path: tstr, delivery_preset: tstr, tcp_port: int) -> result
+  ; Storage lives under the instance directory the host assigns; init fails when
+  ; the host assigned none.
+  method init(delivery_preset: tstr, tcp_port: int) -> result
   method shutdown() -> result
 
   ; --- identity ---

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -50,6 +50,8 @@ pub(crate) enum CoreError {
 /// Failure modes for [`initialize`].
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum InitError {
+    #[error("host did not assign an instance persistence path; start the host with a session or config dir")]
+    NoPersistencePath,
     #[error("{0}")]
     Internal(String),
     #[error("{0}")]
@@ -90,20 +92,27 @@ struct StatusView {
 
 // ── Lifecycle ────────────────────────────────────────────────────────────────
 
-pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> {
-    fs::create_dir_all(instance_path)
-        .map_err(|e| InitError::Internal(format!("cannot create instance_path: {e}")))?;
+pub(crate) fn initialize() -> Result<ModuleState, InitError> {
+    // A host that never set a persistence base path still stamps a context, with
+    // the path left empty, so emptiness is the "host not configured" signal.
+    let persistence_path = crate::context()
+        .map(|ctx| ctx.instance_persistence_path)
+        .filter(|path| !path.is_empty())
+        .ok_or(InitError::NoPersistencePath)?;
+    fs::create_dir_all(&persistence_path).map_err(|e| {
+        InitError::Internal(format!("cannot create instance persistence path: {e}"))
+    })?;
 
     // Storage backs libchat's identity and MLS/crypto state. Ephemeral by
     // default (see `PERSISTENCE_ENABLED`): DirectV1 has no reload path yet, so an
     // in-memory store is honest about chats not surviving a restart. The
     // SQLCipher path stays here, behind the switch, for when reload lands.
     let storage = if PERSISTENCE_ENABLED {
-        let db_path = format!("{instance_path}/identity.db");
-        // Static key derived from the instance path. Not secret; satisfies
+        let db_path = format!("{persistence_path}/identity.db");
+        // Static key derived from the persistence path. Not secret; satisfies
         // SQLCipher's keying requirement. A user-provided passphrase is a
         // future enhancement.
-        let key = format!("rust-chat-{}", instance_path.replace('/', "_"));
+        let key = format!("rust-chat-{}", persistence_path.replace('/', "_"));
         ChatStorage::new(StorageConfig::Encrypted { path: db_path, key })
             .map_err(|e| InitError::Internal(format!("open store failed: {e:?}")))?
     } else {
@@ -160,7 +169,7 @@ pub(crate) fn initialize(instance_path: &str) -> Result<ModuleState, InitError> 
     // so `get_address` needn't take the client lock.
     let address = account_addr;
 
-    let state_path = PathBuf::from(format!("{instance_path}/history.json"));
+    let state_path = PathBuf::from(format!("{persistence_path}/history.json"));
     let state = load_display(&state_path);
 
     // Register listeners before the node starts — `connectionStateChanged`

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -28,8 +28,9 @@
 //! the generated `emit_*` functions (see the included scaffold), which the host
 //! marshals onto the Qt thread and republishes as IPC events.
 //!
-//! Security. The identity store opened by `init` is keyed from
-//! `instance_path` — obfuscated, not protected. Passphrase UX is planned.
+//! Security. The identity store opened by `init` is keyed from the
+//! host-assigned instance persistence path: obfuscated, not protected.
+//! Passphrase UX is planned.
 
 mod actions;
 mod delivery;
@@ -70,12 +71,7 @@ const ERR_LOCK_POISONED: &str = "internal error: module lock poisoned";
 struct ChatModuleImpl;
 
 impl ChatModule for ChatModuleImpl {
-    fn init(
-        &mut self,
-        instance_path: String,
-        delivery_preset: String,
-        tcp_port: i64,
-    ) -> Result<Value, String> {
+    fn init(&mut self, delivery_preset: String, tcp_port: i64) -> Result<Value, String> {
         panic_hook::install_once();
 
         let preset = if delivery_preset.is_empty() {
@@ -84,7 +80,7 @@ impl ChatModule for ChatModuleImpl {
             delivery_preset.as_str()
         };
 
-        match module().install_with(|| actions::initialize(&instance_path)) {
+        match module().install_with(actions::initialize) {
             Err(_) => Err(ERR_LOCK_POISONED.to_string()),
             Ok(Ok(InstallOutcome::Installed)) => {
                 // State is installed and the module lock is released; only now

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -2,9 +2,9 @@
 //!
 //! ## File
 //!
-//! Lives at `<instance_path>/history.json`, where `instance_path` is the
-//! same value passed to `init`. Format is the pretty-printed
-//! JSON serialisation of [`AppState`].
+//! Lives at `history.json` inside the instance persistence path the host
+//! assigns (`RustModuleContext::instance_persistence_path`). Format is the
+//! pretty-printed JSON serialisation of [`AppState`].
 //!
 //! ## Write triggers
 //!


### PR DESCRIPTION
Every module instance is handed a persistence directory by its host, but this module ignored it and made the caller supply a path through init, so the host could hand out one directory while the caller wrote somewhere else entirely, and two instances stayed isolated only as long as whoever launched them remembered to pass different paths.

An absent or empty path is an init failure naming the fix rather than a fallback to a module-chosen location: a host that never configured a persistence base still stamps a context with the path left empty, so resolving a path of our own would hide exactly that misconfiguration.

