### PR TITLE
feat: let the delivery node pick its own port

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -9,8 +9,8 @@ name: Doc-Tests
 # does not complete.
 #
 # Linux-only: it runs several real delivery instances on one host (distinct data
-# dirs and delivery ports). The exchanges need outbound network to reach the
-# logos.test Waku fleet, which GitHub-hosted runners have.
+# dirs). The exchanges need outbound network to reach the logos.test Waku fleet,
+# which GitHub-hosted runners have.
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -88,14 +88,15 @@ positional arguments in `.lidl` order:
 
 End-to-end chat needs a `delivery_module` available to the host at runtime; the
 flake pins [`logos-delivery-module`](https://github.com/logos-co/logos-delivery-module)
-at `v0.1.2`. Load `chat_module` via `logoscore` or Basecamp.
+at `v0.1.3`. Load `chat_module` via `logoscore` or Basecamp.
 
-Bring-up is `init(delivery_preset, tcp_port)` (empty preset → `logos.dev`).
+Bring-up is `init(delivery_preset)` (empty preset → `logos.dev`).
 `init` starts delivery asynchronously and returns immediately; readiness arrives
 later as a `delivery_state_changed` event reaching `online`. State is written to
 the instance directory the host assigns, so running two instances side by side
 is a matter of giving each host its own session directory (`--config-dir` under
-`logoscore`); `init` fails when the host assigned no such directory.
+`logoscore`); `init` fails when the host assigned no such directory. The delivery
+node listens on ports it picks itself, so instances need no port coordination.
 
 ## Doc-tests
 

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -109,8 +109,8 @@ sections:
       own tree, so a `logoscore call --config-dir alice ...` always reaches Alice's
       daemon. That is also what isolates the two `chat_module` instances on disk:
       the daemon assigns each module instance a directory under its config dir,
-      and the module stores everything there. (Their delivery nodes are kept apart
-      separately, by the distinct `tcp_port` passed to `init` in the next step.)
+      and the module stores everything there. (Their delivery nodes need no such
+      scoping: each picks its own listening ports.)
     steps:
       - title: "Start Alice's daemon"
         run: "sh -c './logos/bin/logoscore --config-dir alice -D -m ./modules > alice-daemon.log 2>&1 &'"
@@ -151,27 +151,26 @@ sections:
   - title: "Bring both instances online"
     step: true
     text: |
-      `init(delivery_preset, tcp_port)` returns immediately and kicks off the
+      `init(delivery_preset)` returns immediately and kicks off the
       delivery bootstrap asynchronously; readiness arrives later when the
       subscribe handshake completes and `status().delivery_state` flips to
       `online`. Both instances are initialised **first** so their two cold Waku
       bootstraps overlap, then each is polled; the wait is ~the slower of the two,
       not their sum.
     steps:
-      - title: "Initialise Alice (delivery port 60010) and Bob (60011)"
+      - title: "Initialise Alice and Bob"
         run: |
-          ./logos/bin/logoscore --config-dir alice call chat_module init logos.test 60010
-          ./logos/bin/logoscore --config-dir bob   call chat_module init logos.test 60011
+          ./logos/bin/logoscore --config-dir alice call chat_module init logos.test
+          ./logos/bin/logoscore --config-dir bob   call chat_module init logos.test
         code_block: |
-          logoscore --config-dir alice call chat_module init logos.test 60010
-          logoscore --config-dir bob   call chat_module init logos.test 60011
+          logoscore --config-dir alice call chat_module init logos.test
+          logoscore --config-dir bob   call chat_module init logos.test
         expect_contains:
           - '"status":"ok"'
         post_text: |
-          A distinct `tcp_port` per instance: it is bound for both the Waku TCP
-          listener and the discv5 UDP port, so the two nodes must not share it.
-          Storage needs no argument: each instance uses the directory its daemon
-          assigned it.
+          Neither storage nor ports need an argument: each instance uses the
+          directory its daemon assigned it, and its delivery node listens on
+          ports it picks itself.
       - title: "Wait for both to reach Online"
         run: |
           for who in alice bob; do

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -100,8 +100,8 @@ sections:
       One module is a per-host singleton inside a daemon, so Alice, Bob, and
       Carol are **separate daemons**, kept apart by `--config-dir` (control
       socket, client token, persistence, and the per-instance directory each daemon
-      assigns its `chat_module`) and, in the next step, by distinct
-      `tcp_port`s for their delivery nodes.
+      assigns its `chat_module`). Their delivery nodes need no such scoping: each
+      picks its own listening ports.
     steps:
       - title: "Start the three daemons"
         run: |
@@ -148,34 +148,32 @@ sections:
   - title: "Bring the three instances online"
     step: true
     text: |
-      `init(delivery_preset, tcp_port)` returns immediately and kicks off the
+      `init(delivery_preset)` returns immediately and kicks off the
       delivery bootstrap asynchronously; readiness arrives later when
       `status().delivery_state` flips to `online`. All three are
       initialised **first** so their cold Waku bootstraps overlap, then each is
       polled; the wait is ~the slowest of the three, not their sum.
     steps:
-      - title: "Initialise Alice (60020), Bob (60021), and Carol (60022)"
+      - title: "Initialise Alice, Bob, and Carol"
         run: |
           for who in alice bob carol; do
-            case "$who" in alice) port=60020;; bob) port=60021;; carol) port=60022;; esac
-            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init logos.test "$port")
+            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init logos.test)
             echo "$out"
             echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "$who init failed: $out" >&2; exit 1; }
             echo "${who}_INIT_OK"
           done
         code_block: |
-          logoscore --config-dir alice call chat_module init logos.test 60020
-          logoscore --config-dir bob   call chat_module init logos.test 60021
-          logoscore --config-dir carol call chat_module init logos.test 60022
+          logoscore --config-dir alice call chat_module init logos.test
+          logoscore --config-dir bob   call chat_module init logos.test
+          logoscore --config-dir carol call chat_module init logos.test
         expect_contains:
           - "alice_INIT_OK"
           - "bob_INIT_OK"
           - "carol_INIT_OK"
         post_text: |
-          A distinct `tcp_port` per instance: it is bound for both the Waku TCP
-          listener and the discv5 UDP port, so no two nodes may share one.
-          Storage needs no argument: each instance uses the directory its daemon
-          assigned it.
+          Neither storage nor ports need an argument: each instance uses the
+          directory its daemon assigned it, and its delivery node listens on
+          ports it picks itself.
       - title: "Wait for all three to reach Online"
         run: |
           for who in alice bob carol; do

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -54,7 +54,7 @@ module chat_module {
   ; --- lifecycle ---
   ; Storage lives under the instance directory the host assigns; init fails when
   ; the host assigned none.
-  method init(delivery_preset: tstr, tcp_port: int) -> result
+  method init(delivery_preset: tstr) -> result
   method shutdown() -> result
 
   ; --- identity ---

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -239,12 +239,12 @@ pub(crate) fn initialize() -> Result<ModuleState, InitError> {
 /// chat_module can't coexist with another delivery_module consumer today. Drop
 /// these calls once the host bootstraps delivery_module and exposes it
 /// ready-to-use.
-pub(crate) fn start_delivery_bootstrap(preset: &str, tcp_port: i32) {
+pub(crate) fn start_delivery_bootstrap(preset: &str) {
+    // No listening ports: delivery_module assigns a free one to every socket the
+    // config leaves unpinned, which is what keeps instances sharing a host apart.
     let config_json = serde_json::json!({
         "mode": "Core",
         "preset": preset,
-        "tcpPort": tcp_port,
-        "discv5UdpPort": tcp_port,
         "logLevel": "ERROR",
     })
     .to_string();

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -71,7 +71,7 @@ const ERR_LOCK_POISONED: &str = "internal error: module lock poisoned";
 struct ChatModuleImpl;
 
 impl ChatModule for ChatModuleImpl {
-    fn init(&mut self, delivery_preset: String, tcp_port: i64) -> Result<Value, String> {
+    fn init(&mut self, delivery_preset: String) -> Result<Value, String> {
         panic_hook::install_once();
 
         let preset = if delivery_preset.is_empty() {
@@ -86,7 +86,7 @@ impl ChatModule for ChatModuleImpl {
                 // State is installed and the module lock is released; only now
                 // bootstrap delivery, so its async completion callbacks acquire
                 // a free lock instead of re-entering the one init holds.
-                actions::start_delivery_bootstrap(preset, tcp_port as i32);
+                actions::start_delivery_bootstrap(preset);
                 Ok(Value::Null)
             }
             Ok(Ok(InstallOutcome::AlreadyInstalled)) => {


### PR DESCRIPTION
Chat has no stake in which port its delivery node listens on, yet init made the caller name one, so every host running two instances had to invent a port scheme and thread it through the calls, the docs, and the doc-tests.

delivery_module already assigns a free port to every listening socket the config leaves unpinned, so pinning one was chat opting out of a decision the transport makes better. Dropping the parameter and the pinned ports hands it back.

