### PR TITLE
fix: release delivery_module subscriptions on the dispatch thread

### DIFF
--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -272,16 +272,22 @@ fn set_delivery_error(detail: String) {
 /// deadlock on its own next acquire.
 pub(crate) fn shutdown(mut ms: ModuleState) {
     ms.inbound_stop.store(true, Ordering::Relaxed);
-    if let Some(handle) = ms.inbound_thread.take() {
-        // Bounded by inbound::POLL_INTERVAL; ~50 ms worst case.
-        let _ = handle.join();
-    }
+    // Bounded by inbound::POLL_INTERVAL; ~50 ms worst case. The join hands the
+    // bridge's subscriptions back to this thread rather than letting the worker
+    // drop them (see inbound::BridgeSubscriptions) — but hold them until the
+    // client's own workers are gone: while any remain, a `publish` racing this
+    // teardown must find the cached delivery_module client still alive, or it
+    // would build a fresh one owned by a thread with no Qt event loop.
+    let bridge_subs = ms.inbound_thread.take().map(|handle| handle.join());
     // Drop the client so its worker stops and its event sender disconnects; the
     // event consumer then ends its loop and can be joined.
     drop(ms.client);
     if let Some(handle) = ms.event_thread.take() {
         let _ = handle.join();
     }
+    // Nothing can publish now: release the delivery_module client here, on the
+    // dispatch thread that created it and owns its Qt transport.
+    drop(bridge_subs);
     with_display_mut(|d| {
         // Final write; nothing left to propagate to, so log a failure.
         if let Err(e) = save_display(d) {

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -32,13 +32,25 @@ use crate::persistence::ConversationKind;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// The subscriptions the bridge polls, handed back when it stops.
+///
+/// The bridge must never DROP these itself. Each one holds a share of the
+/// delivery_module client, and dropping the last share destroys that client's
+/// Qt transport — legal only on the thread that created it (the dispatch
+/// thread, where `init` ran), never on this worker. Off-thread teardown makes
+/// Qt disable a socket notifier cross-thread and closes the fd under the
+/// dispatch thread's event loop, which crashed the module on shutdown.
+/// Returning them means `join()` moves them back to the dispatch thread, where
+/// [`crate::actions::shutdown`] releases them at the right moment.
+pub(crate) type BridgeSubscriptions = (EventSubscription, Option<EventSubscription>);
+
 pub(crate) fn spawn_bridge(
     stop: Arc<AtomicBool>,
     messages: EventSubscription,
     conn: Option<EventSubscription>,
     inbound_tx: Sender<Vec<u8>>,
     subscribe_rx: Receiver<String>,
-) -> JoinHandle<()> {
+) -> JoinHandle<BridgeSubscriptions> {
     thread::Builder::new()
         .name("rust-chat-bridge".into())
         .spawn(move || run_bridge(stop, messages, conn, inbound_tx, subscribe_rx))
@@ -55,20 +67,23 @@ pub(crate) fn spawn_events(events: Receiver<Event>) -> JoinHandle<()> {
 fn run_bridge(
     stop: Arc<AtomicBool>,
     messages: EventSubscription,
-    mut conn: Option<EventSubscription>,
+    conn: Option<EventSubscription>,
     inbound_tx: Sender<Vec<u8>>,
     subscribe_rx: Receiver<String>,
-) {
+) -> BridgeSubscriptions {
+    // Set once the connection subscription's sender hangs up. It only stops us
+    // re-polling a dead subscription — the subscription itself stays alive and
+    // goes back with the return value, because this thread must not drop it
+    // (see `BridgeSubscriptions`).
+    let mut conn_dead = false;
     while !stop.load(Ordering::Relaxed) {
         match messages.receiver().recv_timeout(POLL_INTERVAL) {
             Ok(evt) => forward_message(&evt, &inbound_tx),
             Err(RecvTimeoutError::Timeout) => {}
-            Err(RecvTimeoutError::Disconnected) => return,
+            Err(RecvTimeoutError::Disconnected) => break,
         }
 
-        // On Disconnected, drop the subscription so we stop re-polling a dead one.
-        let mut disconnected = false;
-        if let Some(events) = conn.as_ref() {
+        if let Some(events) = conn.as_ref().filter(|_| !conn_dead) {
             loop {
                 match events.receiver().try_recv() {
                     Ok(evt) => {
@@ -80,18 +95,16 @@ fn run_bridge(
                     }
                     Err(TryRecvError::Empty) => break,
                     Err(TryRecvError::Disconnected) => {
-                        disconnected = true;
+                        conn_dead = true;
                         break;
                     }
                 }
             }
         }
-        if disconnected {
-            conn = None;
-        }
 
         forward_subscriptions(&subscribe_rx);
     }
+    (messages, conn)
 }
 
 /// Decode a `messageReceived` event and push its payload to the client's inbound

--- a/rust-lib/src/module.rs
+++ b/rust-lib/src/module.rs
@@ -29,6 +29,7 @@ use logos_generic_chat::{ChatClient, HttpRegistry};
 use serde::Serialize;
 
 use crate::delivery::SdkDelivery;
+use crate::inbound::BridgeSubscriptions;
 use crate::persistence::AppState;
 
 /// The chat client as this module configures it: a delegate identity associated
@@ -107,8 +108,10 @@ pub(crate) struct ModuleState {
     pub inbound_stop: Arc<AtomicBool>,
     /// Inbound bridge worker handle (delivery_module events → client, connection
     /// state, subscription forwarding). `Option` so `shutdown()` can `take()` it
-    /// before `join`-ing while still under the module mutex.
-    pub inbound_thread: Option<JoinHandle<()>>,
+    /// before `join`-ing while still under the module mutex. The join yields the
+    /// worker's subscriptions back to the dispatch thread, which is the only
+    /// thread allowed to release them (see [`crate::inbound::BridgeSubscriptions`]).
+    pub inbound_thread: Option<JoinHandle<BridgeSubscriptions>>,
     /// Event consumer worker handle. Drains the client's `Receiver<Event>`; it
     /// exits once the client is dropped and the event sender disconnects.
     pub event_thread: Option<JoinHandle<()>>,


### PR DESCRIPTION
## The crash

`chat_module` takes SIGSEGV when the UI unloads and calls `chat_module.shutdown()`:

```
[chat_module] ModuleProxy: callRemoteMethod "shutdown" args: 0
[chat_module] QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread
[chat_module] QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread
[chat_module] QSocketNotifier: Invalid socket 21 with type Read, disabling...
[chat_module] FATAL: module 'chat_module' crashed (signal 11)
```

~19 ms after the `shutdown` call — one `POLL_INTERVAL` wake — and the backtrace bottoms out in `_pthread_start`, so the fault is on a worker thread.

## Cause

The bridge worker owned the two `delivery_module` `EventSubscription`s: they are moved into it at init (`actions.rs`, `spawn_bridge`) and dropped when `run_bridge` returns.

Each holds an `Arc<ClientHandle>`, and the rust-sdk's client cache keeps only a `Weak` — so those two were the **last** shares. `shutdown` sets the stop flag and joins; the worker returns, its locals drop, and `lp_client_destroy` runs **on the bridge thread**.

That destroys the client's Qt transport off the thread that created it. Over QtRO it tears down the node's `QLocalSocket` and its socket notifiers cross-thread (the two warnings), the fd closes under the dispatch thread's event dispatcher (`Invalid socket 21`), and the process faults.

## Fix

`run_bridge` returns its subscriptions rather than dropping them, so `join()` moves them back to the dispatch thread — the one that created the client and owns its transport.

Two details the change pins down:

- **The `Disconnected` arm no longer does `conn = None`.** That was a subscription drop on the worker too. It now sets a `conn_dead` flag, which stops the re-polling without releasing anything. The invariant is "this thread never drops an lp handle", and it should hold with no exceptions.
- **`shutdown` holds the returned subscriptions until after `drop(ms.client)` and the event-thread join.** Releasing them at the join would destroy the `delivery_module` client while libchat workers can still `publish` — and a `publish` racing that would miss the cache and build a fresh client owned by a thread with no Qt event loop (`SdkDelivery::publish` runs on libchat's worker). Today that hazard is masked because the bridge's shares keep the cached client alive; this ordering keeps it masked.

## Relationship to logos-protocol#27

Independent, and both are worth having:

- logos-co/logos-protocol#27 makes an off-thread `lp_client_destroy` **safe in general** (defers the teardown to the owner thread) — the safety net for every language binding that can park a client share in a worker.
- This PR removes the off-thread drop **at the source**, so `chat_module` does not depend on that net.

## Verification — reproduced and fixed

The crash reproduces **headlessly**, no GUI needed: it needs only `init` (which spawns the bridge holding the subscriptions) followed by `shutdown` (which joins it).

```
logoscore --config-dir C -D -m MODULES &
logoscore --config-dir C load-module chat_module
logoscore --config-dir C call chat_module init DATA logos.test PORT
# wait until status().delivery_state is online
logoscore --config-dir C call chat_module shutdown
```

Both sides built from this repo's own `flake.lock`, so the **only** difference is the three source files in this PR. `delivery_module` and `logos-protocol` are byte-identical across arms — this isolates the chat-module fix.

| marker in daemon log | before (master `afb9655`) | after (this PR) |
|---|---|---|
| `notifiers cannot be enabled ... another thread` | **2** | 0 |
| `Invalid socket N with type Read` | **1** | 0 |
| `FATAL: module 'chat_module' crashed (signal 11)` | **1** | 0 |
| `Module process crashed: chat_module` | **1** | 0 |

Deterministic: **3/3 runs each way.**

The reproduced backtrace matches the originally reported one frame-for-frame in structure, including a byte-identical `_sigtramp` frame (`0x18f387744`).

### One trap worth recording

Shutting down **immediately** after `init` does **not** crash, on either side. `start_delivery_bootstrap`'s `start_async` holds its own `Arc<ClientHandle>` until its completion callback runs, so until delivery settles the bridge's drop is not the last one and no destroy happens. My first run did exactly this and came back clean on both arms — a false pass. Waiting for `delivery_state` to reach `online` is what makes the bug fire.

That also explains why the original report came from a long-running Basecamp session: by then the bootstrap had long completed and the bridge held the only remaining shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
