### PR TITLE
feat: report a conversation's roster with its pending invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ peer at a time with `add_group_member(convo_id, peer_address)`; every member
 sees the same conversation id, and adds are committed by the group's steward
 asynchronously, so a peer joins some time after the call returns. A group's
 `name` and `desc` are shared metadata carried to every joiner, both optional.
-`list_group_members(convo_id)` returns a group's roster from libchat's MLS
-state. The `Conversation` record and the `conversation_created` event carry a
-`kind` (`"direct"` or `"group"`) distinguishing the two shapes, plus a group's
-shared `name` and `description` (unset for direct conversations and unnamed
-groups). Received
+`list_group_members(convo_id)` returns a conversation's roster from libchat's
+MLS state, including invites this instance has sent that the group has not
+committed yet, flagged `pending`; a direct conversation reports both
+participants and never a pending one. The `Conversation` record and the
+`conversation_created` event carry a `kind` (`"direct"` or `"group"`)
+distinguishing the two shapes, plus a group's shared `name` and `description`
+(unset for direct conversations and unnamed groups). Received
 messages carry a `sender` (on the `Message` record and the `message_received`
 event): the sender's directory-verified account address, or its device id
 when the sender claims no account.

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -312,7 +312,7 @@ sections:
           for who in alice bob carol; do
             ok=""
             for i in $(seq 1 60); do
-              roster=$(./logos/bin/logoscore --config-dir "$who" call chat_module list_group_members "$gid" 2>/dev/null | jq -r '.result[]?.address' || true)
+              roster=$(./logos/bin/logoscore --config-dir "$who" call chat_module list_group_members "$gid" 2>/dev/null | jq -r '.result[]? | select(.pending | not) | .address' || true)
               if printf '%s\n' "$roster" | grep -qF "$a" && printf '%s\n' "$roster" | grep -qF "$b" && printf '%s\n' "$roster" | grep -qF "$c"; then
                 ok=1; echo "$(echo "$who" | tr a-z A-Z)_ROSTER_COMPLETE"; break
               fi
@@ -331,9 +331,11 @@ sections:
           - "CAROL_ROSTER_COMPLETE"
         post_text: |
           `list_group_members` reports the group's roster from libchat's MLS
-          state, each member as its directory-verified account address. All
-          three converge on the same three-member set once the adds have
-          committed everywhere.
+          state, each member as its directory-verified account address. An
+          invite the instance has sent but the group has not committed yet is
+          listed too, flagged `pending`, so this poll skips those. All three
+          converge on the same three-member set once the adds have committed
+          everywhere.
 
   - title: "Messages fan out to every member, with senders attributed"
     step: true

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "chat-proto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/chat_proto?rev=37ec98a151f6d50aab2905802ac0a896477e62ea#37ec98a151f6d50aab2905802ac0a896477e62ea"
+source = "git+https://github.com/logos-messaging/chat_proto?rev=948f4ad6dedb01b44e279204d8eb30a1eda5a330#948f4ad6dedb01b44e279204d8eb30a1eda5a330"
 dependencies = [
  "prost",
 ]
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "chat-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "crypto",
  "hex",
@@ -1306,17 +1306,18 @@ dependencies = [
 [[package]]
 name = "components"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "base64",
+ "chat-proto",
  "crossbeam-channel",
  "crypto",
  "hex",
  "libchat",
  "logos-account",
+ "prost",
  "reqwest 0.12.28",
  "serde",
- "serde_json",
  "storage",
  "thiserror",
  "tracing",
@@ -1479,7 +1480,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.4.1",
@@ -1737,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "double-ratchets"
 version = "0.0.1"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -2891,7 +2892,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libchat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "alloy",
  "base64",
@@ -3228,7 +3229,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-account"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "crypto",
  "hex",
@@ -3239,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "logos-generic-chat"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "chat-sqlite",
  "components",
@@ -4863,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "shared-traits"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "crypto",
 ]
@@ -4950,7 +4951,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/logos-messaging/libchat.git?rev=0c51d4d0b8d83223a133a157e186f0b9a18527ca#0c51d4d0b8d83223a133a157e186f0b9a18527ca"
+source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
 dependencies = [
  "crypto",
  "thiserror",

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -32,15 +32,15 @@ panic = "abort"
 # the `group_members` roster, the Event::ConversationMembersChanged behind the
 # `members_changed` contract event, injectable GroupV2 timing, the honest DirectV1
 # display class). Not yet in a released libchat version.
-logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
+logos-generic-chat = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-generic-chat", rev = "5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14" }
 # The umbrella `libchat` crate, for `ChatStorage`: the builder's
 # `storage_config` panics on a bad DB, so we build the store fallibly and pass it in.
-libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
+libchat        = { git = "https://github.com/logos-messaging/libchat.git", package = "libchat", rev = "5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14" }
 # `TestLogosAccount` (gated behind logos-account's `dev` feature): the ephemeral
 # account identity that signs this installation's device bundle and whose key is
 # the shared account address. Enable `dev` on our own dep so its availability
 # doesn't hinge on another crate happening to turn the feature on.
-logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "0c51d4d0b8d83223a133a157e186f0b9a18527ca" }
+logos-account  = { git = "https://github.com/logos-messaging/libchat.git", package = "logos-account", features = ["dev"], rev = "5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14" }
 # The client hands back a `Receiver<Event>` and drains a `Receiver<Vec<u8>>`
 # through its `Transport`, so the module's plumbing speaks the same channel type.
 crossbeam-channel = "0.5"

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -49,6 +49,12 @@ module chat_module {
     ; The member's directory-verified account address, or empty when the member
     ; claims no confirmed account (the UI renders these as an unknown account).
     address: tstr
+    ; True while the group has not committed this member's add, so it cannot
+    ; read the conversation yet. Only invites this instance sent are reported, so
+    ; a member another instance invited appears once the group commits it. The
+    ; flag clears when that commit lands; an invite the group never commits stays
+    ; pending for the life of the conversation.
+    pending: bool
   }
 
   ; --- lifecycle ---
@@ -79,8 +85,10 @@ module chat_module {
   method add_group_member(convo_id: tstr, peer_address: tstr) -> result
   method list_conversations() -> [Conversation]
   method get_messages(convo_id: tstr) -> [Message]
-  ; The roster of a group conversation, one GroupMember per element. Errors when
-  ; convo_id names a direct (non-group) conversation.
+  ; The roster of a conversation, one GroupMember per element: committed members
+  ; first, then invites still awaiting the group's commit. A direct conversation
+  ; reports both participants and never a pending one; an unknown conversation
+  ; reports an empty roster.
   method list_group_members(convo_id: tstr) -> [GroupMember]
   method send_message(convo_id: tstr, content: tstr) -> result
   method set_conversation_nickname(convo_id: tstr, nickname: tstr) -> result

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -14,7 +14,8 @@ use std::sync::Arc;
 use libchat::ChatStorage;
 use logos_account::TestLogosAccount;
 use logos_generic_chat::{
-    ChatClientBuilder, DelegateSigner, GroupMetadata, HttpRegistry, StorageConfig,
+    ChatClientBuilder, ContactRegistry, DelegateSigner, GroupMetadata, RegistryPublishMode,
+    StorageConfig,
 };
 use serde::Serialize;
 
@@ -148,10 +149,19 @@ pub(crate) fn initialize() -> Result<ModuleState, InitError> {
     let account_addr = account.address();
     let delegate = DelegateSigner::random();
     let device_key = delegate.public_key().clone();
+    let transport = SdkDelivery::new(inbound_rx, subscribe_tx);
+    // Submit over the registry's HTTP API, which acknowledges each bundle. The
+    // delivery wire it offers instead is fire-and-forget, so a rejected bundle
+    // would surface only as a peer failing to resolve us much later.
+    let registry = ContactRegistry::new(
+        transport.publisher(),
+        DEFAULT_REGISTRY_URL,
+        RegistryPublishMode::Http,
+    );
     let (client, events) = ChatClientBuilder::new(account_addr.clone())
         .ident(delegate)
-        .transport(SdkDelivery::new(inbound_rx, subscribe_tx))
-        .registration(HttpRegistry::new(DEFAULT_REGISTRY_URL))
+        .transport(transport)
+        .registration(registry.clone())
         .storage(storage)
         .build()
         .map_err(|e| InitError::Internal(format!("client build failed: {e:?}")))?;
@@ -159,7 +169,7 @@ pub(crate) fn initialize() -> Result<ModuleState, InitError> {
     // Endorse the delegate's device key in the registry's account directory so
     // a peer holding only the account address resolves this device's key package.
     // (The client registers its own key package during build.)
-    let mut directory = HttpRegistry::new(DEFAULT_REGISTRY_URL);
+    let mut directory = registry;
     account
         .add_delegate_signer(&mut directory, &device_key)
         .map_err(|e| InitError::Internal(format!("publish device bundle failed: {e:?}")))?;
@@ -478,12 +488,14 @@ fn member_address(member: logos_generic_chat::GroupMember) -> String {
 #[derive(Serialize)]
 struct GroupMemberRow {
     address: String,
+    pending: bool,
 }
 
-/// The roster of the group conversation `convo_id`, one [`GroupMemberRow`] per
-/// element. This is a plain list with no error channel, mirroring `get_messages`:
-/// an unknown or non-group conversation, or a client error, yields an empty
-/// array (the client error is logged).
+/// The roster of the conversation `convo_id`, one [`GroupMemberRow`] per
+/// element; a direct conversation reports both participants. This is a plain
+/// list with no error channel, mirroring `get_messages`: an unknown
+/// conversation, or a client error, yields an empty array (the client error is
+/// logged).
 pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
     let empty = || serde_json::Value::Array(vec![]);
     if !with_display(|d| d.state.chats.contains_key(convo_id)) {
@@ -494,6 +506,7 @@ pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
             let rows: Vec<GroupMemberRow> = members
                 .into_iter()
                 .map(|m| GroupMemberRow {
+                    pending: m.pending,
                     address: member_address(m),
                 })
                 .collect();
@@ -754,12 +767,14 @@ mod tests {
         let verified = GroupMember {
             account: Some(IdentId::new("acct-addr")),
             local_identity: IdentId::new("device-id"),
+            pending: false,
         };
         assert_eq!(member_address(verified), "acct-addr");
 
         let no_account = GroupMember {
             account: None,
             local_identity: IdentId::new("device-id"),
+            pending: false,
         };
         assert_eq!(member_address(no_account), "");
     }

--- a/rust-lib/src/delivery.rs
+++ b/rust-lib/src/delivery.rs
@@ -17,28 +17,60 @@ pub(crate) fn content_topic_for(delivery_address: &str) -> String {
     format!("{TOPIC_PREFIX}{delivery_address}/proto")
 }
 
-/// Carries each direction of the client's delivery boundary: outbound publishing
-/// and subscription forwarding to delivery_module, plus the inbound payload
-/// stream the client's worker drains.
+/// Carries each direction of the client's delivery boundary: the outbound
+/// [`SdkPublisher`], plus the inbound payload stream the client's worker drains.
 #[derive(Debug)]
 pub(crate) struct SdkDelivery {
     /// Handed to the client once via [`Transport::inbound`]. The module feeds the
     /// matching sender from delivery_module's `messageReceived` events.
     inbound_rx: Option<Receiver<Vec<u8>>>,
-    /// Subscription requests from the core, drained by the inbound worker.
-    subscribe_tx: Sender<String>,
+    publisher: SdkPublisher,
 }
 
 impl SdkDelivery {
     pub(crate) fn new(inbound_rx: Receiver<Vec<u8>>, subscribe_tx: Sender<String>) -> Self {
         Self {
             inbound_rx: Some(inbound_rx),
-            subscribe_tx,
+            publisher: SdkPublisher { subscribe_tx },
         }
+    }
+
+    /// A handle on the outbound half alone, for a consumer that publishes over
+    /// the same delivery node but never reads the inbound stream.
+    pub(crate) fn publisher(&self) -> SdkPublisher {
+        self.publisher.clone()
     }
 }
 
 impl DeliveryService for SdkDelivery {
+    type Error = String;
+
+    fn publish(&mut self, envelope: AddressedEnvelope) -> Result<(), String> {
+        self.publisher.publish(envelope)
+    }
+
+    fn subscribe(&mut self, delivery_address: &str) -> Result<(), String> {
+        self.publisher.subscribe(delivery_address)
+    }
+}
+
+impl Transport for SdkDelivery {
+    fn inbound(&mut self) -> Receiver<Vec<u8>> {
+        self.inbound_rx
+            .take()
+            .expect("SdkDelivery::inbound called more than once")
+    }
+}
+
+/// The outbound half of the delivery boundary. Clonable, so a consumer that only
+/// publishes holds its own handle without a second claim on the inbound stream.
+#[derive(Clone, Debug)]
+pub(crate) struct SdkPublisher {
+    /// Subscription requests from the core, drained by the inbound worker.
+    subscribe_tx: Sender<String>,
+}
+
+impl DeliveryService for SdkPublisher {
     type Error = String;
 
     fn publish(&mut self, envelope: AddressedEnvelope) -> Result<(), String> {
@@ -66,13 +98,5 @@ impl DeliveryService for SdkDelivery {
         self.subscribe_tx
             .send(content_topic_for(delivery_address))
             .map_err(|e| e.to_string())
-    }
-}
-
-impl Transport for SdkDelivery {
-    fn inbound(&mut self) -> Receiver<Vec<u8>> {
-        self.inbound_rx
-            .take()
-            .expect("SdkDelivery::inbound called more than once")
     }
 }

--- a/rust-lib/src/module.rs
+++ b/rust-lib/src/module.rs
@@ -25,17 +25,17 @@ use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use libchat::ChatStorage;
-use logos_generic_chat::{ChatClient, HttpRegistry};
+use logos_generic_chat::{ChatClient, ContactRegistry};
 use serde::Serialize;
 
-use crate::delivery::SdkDelivery;
+use crate::delivery::{SdkDelivery, SdkPublisher};
 use crate::persistence::AppState;
 
 /// The chat client as this module configures it: a delegate identity associated
 /// with an ephemeral account, the delivery_module-backed [`SdkDelivery`]
-/// transport, the devnet HTTP registry, and an in-memory store. Chats are
+/// transport, the devnet contact registry, and an in-memory store. Chats are
 /// ephemeral (see [`PERSISTENCE_ENABLED`]).
-pub(crate) type Client = ChatClient<SdkDelivery, HttpRegistry, ChatStorage>;
+pub(crate) type Client = ChatClient<SdkDelivery, ContactRegistry<SdkPublisher>, ChatStorage>;
 
 /// Whether chat state persists across restarts. Off: identity, MLS/crypto state,
 /// and the display history are all ephemeral. DirectV1 has no reload path in


### PR DESCRIPTION
A group add is committed asynchronously, so between the call returning and the commit landing the invited peer appears on no roster at all, leaving a consumer no way to tell an invite in flight from one that was never sent. A direct conversation had no roster to read either.

The GroupMember record gains pending, true for an invite this instance sent that the group has not committed yet; such a member is listed after the committed ones and drops the flag once the commit lands. Only this instance's own invites are reported, so a member another instance invited appears once the group commits it. list_group_members now answers for a direct conversation as well, reporting both participants. The contract version stays at the in-development 0.2.0.

The libchat rev this pins also replaces HttpRegistry with a transport-generic ContactRegistry, so SdkDelivery's outbound half splits out as a clonable SdkPublisher for the registry to publish through, submitting over the store's HTTP API.

