### PR TITLE
ci: adopt the shared setup-nix-cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,17 @@ env:
 jobs:
   lint:
     name: Lint
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
@@ -57,6 +53,7 @@ jobs:
 
   cargo:
     name: cargo (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -66,16 +63,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
@@ -96,6 +88,7 @@ jobs:
 
   nix:
     name: nix (${{ matrix.os }})
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -105,16 +98,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: nix build .#chat_module
         run: nix build .#chat_module -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -28,22 +28,18 @@ permissions:
 jobs:
   doctests:
     name: doc-tests (ubuntu-latest)
+    environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Setup Nix and Logos cache
+        uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       # Resolve the commit under test. For pull requests this is the PR's head
       # commit (not the synthetic merge commit); for pushes it's the pushed commit.
@@ -68,7 +64,7 @@ jobs:
       # Pre-build the closures the spec builds inline, so its bash steps hit the
       # nix store instead of compiling under the run (and inside its poll budgets).
       # chat_module#lgx (libchat + openssl from source) is the heavy, uncached one
-      # (it's the commit under test); logoscore / delivery / lgpm should be cachix
+      # (it's the commit under test); logoscore / delivery / lgpm should be attic
       # hits. Fork PRs blank the SHA -> build the default branch, as the spec does.
       - name: Pre-build doc-test closures
         shell: bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "Logos Chat Module";
 
+  # Pull pre-built artifacts (delivery module, liblogosdelivery, …) from the
+  # self-hosted Logos Attic cache, for local builds too — CI configures its
+  # substituters itself. Read-only and public; see infra-ci#263. Only the
+  # public (master-built) cache belongs here; ci is CI-only by design.
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
+  };
+
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
 


### PR DESCRIPTION
Switches CI off the free Cachix plan to the self-hosted Logos Attic cache (`cache.nix.logos.co`, [infra-ci #263](https://github.com/status-im/infra-ci/issues/263)), using the new shared [`logos-co/setup-nix-cache-action`](https://github.com/logos-co/setup-nix-cache-action). Standalone alternative to #40 — same cache design, but each job's Nix+cache setup is the two-line action call:

```yaml
- uses: logos-co/setup-nix-cache-action@v1
  with:
    attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
    attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
```

The action bakes in the endpoint (public knowledge, not a secret — `ATTIC_ENDPOINT` is no longer needed), the substituters, signing keys, and the master→`public` / else→`ci` publish selection; empty tokens (fork PRs; `ATTIC_TOKEN_PUBLIC` outside the `public-cache` environment) skip publishing instead of failing. A future key rotation becomes a single PR in the action repo. What stays per-job: the `environment:` gate (job-level metadata) and passing the secrets (composite actions can't read them implicitly).

`flake.nix` declares the **public** cache for local builds; `ci` is CI-only by design.

Supersedes the per-repo copies in #40 if we prefer this route — otherwise rebase after #40 merges and the diff collapses to the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)