### PR TITLE
feat: make the chat core audible, and answer whether the module is still there

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ conversation id, an intro bundle, or null), `Err(message)` a human-readable
 reason. Collection getters (`list_conversations`, `get_messages`) return JSON
 arrays. See the `.lidl` for the full method list and record shapes.
 
+`health()` is the exception: it returns `true` and nothing else, needs no `init`,
+and holds no lock, so what a caller learns is whether the call arrived at all. It
+exists because a module that dies takes no part in noticing. Nothing is pushed
+when the process goes, and a consumer otherwise finds out only when the next
+thing it does runs out its own timeout, having looked connected until then.
+Polling this turns that into a bounded delay, and a failed call is the answer.
+
 Two conversation shapes are exposed. `create_conversation(peer_address)` opens
 a 1:1 DirectV1 conversation. `create_group_conversation(name, desc)` creates a
 GroupV2 (de-mls) group with this installation as its only member, grown one

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ from its host, replaces that default outright, so a verbose run names every
 target it wants:
 `RUST_LOG=warn,chat_module=debug,libchat=debug,logos_generic_chat=debug`.
 
+Each line is `<SEVERITY>: <target>: <message>`, with `WARNING` for a warning
+because that is the token a host ranks the line by, and with no timestamp
+because the host stamps what it re-emits. A reader downstream gets the level
+from the host's own column and the domain from the target.
+
 ## Doc-tests
 
 The specs under [`doctests/`](doctests/) are executable usage tutorials: each

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ End-to-end chat needs a `delivery_module` available to the host at runtime; the
 flake pins [`logos-delivery-module`](https://github.com/logos-co/logos-delivery-module)
 at `v0.1.3`. Load `chat_module` via `logoscore` or Basecamp.
 
-Bring-up is `init(delivery_preset)` (empty preset → `logos.dev`).
+Bring-up is `init(config)`, taking a `ChatConfig` record whose every field is
+optional: `delivery_preset` (empty or absent → `logos.dev`) and `log_level`.
 `init` starts delivery asynchronously and returns immediately; readiness arrives
 later as a `delivery_state_changed` event reaching `online`. State is written to
 the instance directory the host assigns, so running two instances side by side
@@ -100,26 +101,58 @@ is a matter of giving each host its own session directory (`--config-dir` under
 `logoscore`); `init` fails when the host assigned no such directory. The delivery
 node listens on ports it picks itself, so instances need no port coordination.
 
-`init` also installs a `tracing` subscriber, so the chat core's log events go to
-the module's stderr and the host forwards them into its own log. Three targets
-carry that account of a run: `libchat` (the conversation core, MLS groups,
-inbox), `logos_generic_chat` (the threaded client and its inbound worker), and
-`chat_module` itself. The module is one of them because the other two are nearly
-silent: between them they raise eleven events, almost all on paths that are
-already failing, so a run that merely behaves oddly would write nothing. This
-module reports its own lifecycle instead, and logs a message as a byte count and
-a conversation id, never as content. The default is
-`warn,chat_module=info,libchat=info,logos_generic_chat=info`, which surfaces the
-chat core's lifecycle without the far larger `info` output of the crates
-underneath it. `RUST_LOG`, read from the environment the module process inherits
-from its host, replaces that default outright, so a verbose run names every
-target it wants:
-`RUST_LOG=warn,chat_module=debug,libchat=debug,logos_generic_chat=debug`.
+A generated client passes the record itself. `logoscore call` cannot — it coerces
+an argument to a bool, a number or a string, never to an object — so from the CLI
+pass the record's JSON text and the module reads it back:
 
-Each line is `<SEVERITY>: <target>: <message>`, with `WARNING` for a warning
-because that is the token a host ranks the line by, and with no timestamp
-because the host stamps what it re-emits. A reader downstream gets the level
-from the host's own column and the domain from the target.
+```bash
+logoscore call chat_module init '{"delivery_preset":"logos.test","log_level":"debug"}'
+```
+
+### Logging
+
+`init` installs a `tracing` subscriber writing to two places: the module's
+stderr, which the host forwards into its own log, and a file in the instance
+directory, which `get_log_path()` names so a consumer can hand the run over
+afterwards. Three targets carry the chat core's account of a run: `libchat` (the
+conversation core, MLS groups, inbox), `logos_generic_chat` (the threaded client
+and its inbound worker), and `chat_module` itself. The module is one of them
+because the other two are nearly silent: between them they raise eleven events,
+almost all on paths that are already failing, so a run that merely behaves oddly
+would write nothing. This module reports its own lifecycle instead, and logs a
+message as a byte count and a conversation id, never as content.
+
+`log_level` sets those three targets and nothing else (`error`, `warn`, `info`,
+`debug` or `trace`, defaulting to `info`), leaving everything around them at
+`warn`, because the crates underneath the chat core have an order of magnitude
+more `info` sites than it does. `RUST_LOG`, read from the environment the module
+process inherits from its host, outranks the client's choice and replaces the
+composition outright, so a verbose run names every target it wants:
+`RUST_LOG=warn,chat_module=debug,libchat=debug,logos_generic_chat=debug`. The
+level is read once, at the first `init`, and a later `init` leaves it as it was.
+
+A panic goes into that file too, with a backtrace. It cannot arrive as a
+`tracing` event, since `panic = "abort"` means the process is already on its way
+down, so the panic hook writes it directly and captures the backtrace whether or
+not `RUST_BACKTRACE` was set.
+
+The file is `chat_module_<stamp>.log`, moved aside as
+`chat_module_<stamp>.NNN.log` when it fills and reopened under the announced
+name, with the ten most recent runs kept. That naming is what lets a consumer
+group the directory into runs — and lets a second writer keep its own log
+alongside without either knowing about the other, since the grouping reads the
+stem off the announced path.
+
+A line on stderr is `<SEVERITY>: <target>: <message>`, with `WARNING` for a
+warning because that is the token a host ranks the line by, and with no timestamp
+because the host stamps what it re-emits. A reader downstream gets the level from
+the host's own column and the domain from the target. The same line in the file
+leads with an ISO-8601 time, because nothing else stamps it and reading it
+against another writer's log takes one.
+
+Only the stderr half meets that host classifier, which is why `debug` and `trace`
+are worth asking for: a host drops what it ranks below its own level, and the
+file is written directly and drops nothing.
 
 ## Doc-tests
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ is a matter of giving each host its own session directory (`--config-dir` under
 `logoscore`); `init` fails when the host assigned no such directory. The delivery
 node listens on ports it picks itself, so instances need no port coordination.
 
+`init` also installs a `tracing` subscriber, so libchat's log events go to the
+module's stderr and the host forwards them into its own log. The default level
+is `warn`; `RUST_LOG`, read from the environment the module process inherits
+from its host, selects more. libchat logs under two targets: `libchat` (the
+conversation core, MLS groups, inbox) and `logos_generic_chat` (the threaded
+client and its inbound worker), so a verbose run is
+`RUST_LOG=warn,libchat=debug,logos_generic_chat=debug`.
+
 ## Doc-tests
 
 The specs under [`doctests/`](doctests/) are executable usage tutorials: each

--- a/README.md
+++ b/README.md
@@ -100,13 +100,21 @@ is a matter of giving each host its own session directory (`--config-dir` under
 `logoscore`); `init` fails when the host assigned no such directory. The delivery
 node listens on ports it picks itself, so instances need no port coordination.
 
-`init` also installs a `tracing` subscriber, so libchat's log events go to the
-module's stderr and the host forwards them into its own log. The default level
-is `warn`; `RUST_LOG`, read from the environment the module process inherits
-from its host, selects more. libchat logs under two targets: `libchat` (the
-conversation core, MLS groups, inbox) and `logos_generic_chat` (the threaded
-client and its inbound worker), so a verbose run is
-`RUST_LOG=warn,libchat=debug,logos_generic_chat=debug`.
+`init` also installs a `tracing` subscriber, so the chat core's log events go to
+the module's stderr and the host forwards them into its own log. Three targets
+carry that account of a run: `libchat` (the conversation core, MLS groups,
+inbox), `logos_generic_chat` (the threaded client and its inbound worker), and
+`chat_module` itself. The module is one of them because the other two are nearly
+silent: between them they raise eleven events, almost all on paths that are
+already failing, so a run that merely behaves oddly would write nothing. This
+module reports its own lifecycle instead, and logs a message as a byte count and
+a conversation id, never as content. The default is
+`warn,chat_module=info,libchat=info,logos_generic_chat=info`, which surfaces the
+chat core's lifecycle without the far larger `info` output of the crates
+underneath it. `RUST_LOG`, read from the environment the module process inherits
+from its host, replaces that default outright, so a verbose run names every
+target it wants:
+`RUST_LOG=warn,chat_module=debug,libchat=debug,logos_generic_chat=debug`.
 
 ## Doc-tests
 

--- a/doctests/chat-module-exchange.test.yaml
+++ b/doctests/chat-module-exchange.test.yaml
@@ -151,7 +151,7 @@ sections:
   - title: "Bring both instances online"
     step: true
     text: |
-      `init(delivery_preset)` returns immediately and kicks off the
+      `init(config)` returns immediately and kicks off the
       delivery bootstrap asynchronously; readiness arrives later when the
       subscribe handshake completes and `status().delivery_state` flips to
       `online`. Both instances are initialised **first** so their two cold Waku
@@ -160,14 +160,19 @@ sections:
     steps:
       - title: "Initialise Alice and Bob"
         run: |
-          ./logos/bin/logoscore --config-dir alice call chat_module init logos.test
-          ./logos/bin/logoscore --config-dir bob   call chat_module init logos.test
+          ./logos/bin/logoscore --config-dir alice call chat_module init '{"delivery_preset":"logos.test"}'
+          ./logos/bin/logoscore --config-dir bob   call chat_module init '{"delivery_preset":"logos.test"}'
         code_block: |
-          logoscore --config-dir alice call chat_module init logos.test
-          logoscore --config-dir bob   call chat_module init logos.test
+          logoscore --config-dir alice call chat_module init '{"delivery_preset":"logos.test"}'
+          logoscore --config-dir bob   call chat_module init '{"delivery_preset":"logos.test"}'
         expect_contains:
           - '"status":"ok"'
         post_text: |
+          `init` takes a `ChatConfig` record, and every field of it is optional:
+          `log_level` is left out here, so the chat core logs at its default. The
+          record arrives as its JSON text because `logoscore call` coerces an
+          argument to a bool, a number or a string, never to an object.
+
           Neither storage nor ports need an argument: each instance uses the
           directory its daemon assigned it, and its delivery node listens on
           ports it picks itself.

--- a/doctests/chat-module-group.test.yaml
+++ b/doctests/chat-module-group.test.yaml
@@ -148,7 +148,7 @@ sections:
   - title: "Bring the three instances online"
     step: true
     text: |
-      `init(delivery_preset)` returns immediately and kicks off the
+      `init(config)` returns immediately and kicks off the
       delivery bootstrap asynchronously; readiness arrives later when
       `status().delivery_state` flips to `online`. All three are
       initialised **first** so their cold Waku bootstraps overlap, then each is
@@ -157,20 +157,25 @@ sections:
       - title: "Initialise Alice, Bob, and Carol"
         run: |
           for who in alice bob carol; do
-            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init logos.test)
+            out=$(./logos/bin/logoscore --config-dir "$who" call chat_module init '{"delivery_preset":"logos.test"}')
             echo "$out"
             echo "$out" | jq -e '.result.success == true' >/dev/null || { echo "$who init failed: $out" >&2; exit 1; }
             echo "${who}_INIT_OK"
           done
         code_block: |
-          logoscore --config-dir alice call chat_module init logos.test
-          logoscore --config-dir bob   call chat_module init logos.test
-          logoscore --config-dir carol call chat_module init logos.test
+          logoscore --config-dir alice call chat_module init '{"delivery_preset":"logos.test"}'
+          logoscore --config-dir bob   call chat_module init '{"delivery_preset":"logos.test"}'
+          logoscore --config-dir carol call chat_module init '{"delivery_preset":"logos.test"}'
         expect_contains:
           - "alice_INIT_OK"
           - "bob_INIT_OK"
           - "carol_INIT_OK"
         post_text: |
+          `init` takes a `ChatConfig` record, and every field of it is optional:
+          `log_level` is left out here, so the chat core logs at its default. The
+          record arrives as its JSON text because `logoscore call` coerces an
+          argument to a bool, a number or a string, never to an object.
+
           Neither storage nor ports need an argument: each instance uses the
           directory its daemon assigned it, and its delivery node listens on
           ports it picks itself.

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing-subscriber",
  "xeddsa",
 ]
 
@@ -2878,6 +2879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3328,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -4862,6 +4887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-traits"
 version = "0.1.0"
 source = "git+https://github.com/logos-messaging/libchat.git?rev=5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14#5c55c2ee76bebd1dbd5eb4bfa95d9e71acd0fa14"
@@ -5081,6 +5115,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -5334,6 +5377,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
 name = "chat_module"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "crossbeam-channel",
  "hex",
  "libchat",
@@ -1257,6 +1258,7 @@ dependencies = [
  "logos-rust-sdk",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tracing",
  "tracing-core",

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-core",
  "tracing-subscriber",
  "xeddsa",
 ]

--- a/rust-lib/Cargo.lock
+++ b/rust-lib/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
  "tracing-subscriber",
  "xeddsa",
 ]

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -55,6 +55,8 @@ thiserror      = "2"
 # Hex-encodes the account verifying key as this installation's shared address,
 # and the delegate device key into the account's signed device bundle.
 hex            = "0.4"
+# The process's `tracing` subscriber (see `logging`); `env-filter` reads `RUST_LOG`.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -55,6 +55,9 @@ thiserror      = "2"
 # Hex-encodes the account verifying key as this installation's shared address,
 # and the delegate device key into the account's signed device bundle.
 hex            = "0.4"
+# This module's own account of a run, raised on the same channel libchat uses so
+# one subscriber and one filter cover both.
+tracing            = "0.1"
 # The process's `tracing` subscriber (see `logging`); `env-filter` reads `RUST_LOG`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -60,6 +60,8 @@ hex            = "0.4"
 tracing            = "0.1"
 # The process's `tracing` subscriber (see `logging`); `env-filter` reads `RUST_LOG`.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# The event and level types the subscriber's line format is written against.
+tracing-core       = "0.1"
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose
@@ -67,3 +69,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # `crypto` crate. Pin to 1.0.2 (libchat's own declared version) to keep
 # the transitive build working.
 xeddsa         = "=1.0.2"
+
+[dev-dependencies]

--- a/rust-lib/Cargo.toml
+++ b/rust-lib/Cargo.toml
@@ -62,6 +62,10 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # The event and level types the subscriber's line format is written against.
 tracing-core       = "0.1"
+# Stamps this run's log file name in local time, which is the naming a consumer
+# groups a log directory into runs by. Already in the graph, so declaring it
+# builds nothing new.
+chrono         = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 # libchat's `crypto` crate is written for the xeddsa 1.0 API. Cargo's
 # default SemVer resolution would pick 1.1.0 (released since), whose
@@ -71,3 +75,5 @@ tracing-core       = "0.1"
 xeddsa         = "=1.0.2"
 
 [dev-dependencies]
+# A directory the run-log tests can rotate and prune in.
+tempfile = "3"

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -58,10 +58,21 @@ module chat_module {
   }
 
   ; --- lifecycle ---
+  type ChatConfig {
+    ; The delivery network to join. Empty or absent means "logos.dev".
+    ? delivery_preset: tstr
+    ; How much of the chat core's own account of a run to log:
+    ; "error" | "warn" | "info" | "debug" | "trace". Absent or unrecognised
+    ; means "info". Read once, at init: a later init leaves it as it was.
+    ? log_level: tstr
+  }
   ; Storage lives under the instance directory the host assigns; init fails when
   ; the host assigned none.
-  method init(delivery_preset: tstr) -> result
+  method init(config: ChatConfig) -> result
   method shutdown() -> result
+  ; The file this module is writing its log to, in the instance directory the
+  ; host assigned. Empty before init, and on a host that assigned none.
+  method get_log_path() -> tstr
 
   ; --- identity ---
   method get_installation_name() -> tstr

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -73,6 +73,10 @@ module chat_module {
   ; The file this module is writing its log to, in the instance directory the
   ; host assigned. Empty before init, and on a host that assigned none.
   method get_log_path() -> tstr
+  ; Liveness. Always true, and reachable without init or any lock held, so what
+  ; a caller learns is whether this module answered at all: a host that lost the
+  ; process fails the call instead, and a false is that failure surfacing.
+  method health() -> bool
 
   ; --- identity ---
   method get_installation_name() -> tstr

--- a/rust-lib/src/actions.rs
+++ b/rust-lib/src/actions.rs
@@ -195,7 +195,7 @@ pub(crate) fn initialize() -> Result<ModuleState, InitError> {
         Err(e) => {
             // Non-fatal: messaging still works; we just won't surface
             // delivery_state changes pushed by the node.
-            eprintln!("chat_module init: subscribe(connectionStateChanged) failed: {e}");
+            tracing::error!("init: subscribe(connectionStateChanged) failed: {e}");
             None
         }
     };
@@ -279,9 +279,8 @@ fn start_node() {
         });
 }
 
-/// Record an async-bootstrap failure: log it and reflect it in delivery_state.
+/// Record an async-bootstrap failure in delivery_state, which is what logs it.
 fn set_delivery_error(detail: String) {
-    eprintln!("chat_module: {detail}");
     with_display_mut(|d| set_delivery_state(d, DeliveryStateKind::Error, &detail));
 }
 
@@ -304,7 +303,7 @@ pub(crate) fn shutdown(mut ms: ModuleState) {
     with_display_mut(|d| {
         // Final write; nothing left to propagate to, so log a failure.
         if let Err(e) = save_display(d) {
-            eprintln!("chat_module: save_state failed on shutdown: {e}");
+            tracing::error!("save_state failed on shutdown: {e}");
         }
         *d = Display::default();
     });
@@ -394,6 +393,7 @@ pub(crate) fn create_conversation(peer_address: &str) -> Result<String, CoreErro
     let chat_id = with_client(|client| client.create_direct_conversation(peer_address))?
         .map_err(|e| CoreError::Internal(format!("create_conversation failed: {e:?}")))?;
 
+    tracing::info!("created direct conversation {chat_id}");
     let peer_label = short_label(&chat_id).to_owned();
     with_display_mut(|d| {
         d.state.chats.insert(
@@ -430,6 +430,8 @@ pub(crate) fn create_group_conversation(name: &str, desc: &str) -> Result<String
         client.create_group_conversation(&[], GroupMetadata::new(name, desc))
     })?
     .map_err(|e| CoreError::Internal(format!("create_group_conversation failed: {e:?}")))?;
+
+    tracing::info!("created group conversation {chat_id}");
 
     let label = short_label(&chat_id).to_owned();
     with_display_mut(|d| {
@@ -513,11 +515,11 @@ pub(crate) fn list_group_members(convo_id: &str) -> serde_json::Value {
             serde_json::to_value(rows).unwrap_or_else(|_| empty())
         }
         Ok(Err(e)) => {
-            eprintln!("chat_module: list_group_members failed: {e:?}");
+            tracing::warn!("list_group_members failed: {e:?}");
             empty()
         }
         Err(e) => {
-            eprintln!("chat_module: list_group_members: {e}");
+            tracing::warn!("list_group_members: {e}");
             empty()
         }
     }
@@ -569,6 +571,10 @@ pub(crate) fn send_message(convo_id: &str, content: &str) -> Result<(), CoreErro
 
     with_client(|client| client.send_message(convo_id, content.as_bytes()))?
         .map_err(|e| CoreError::Delivery(format!("send_message failed: {e:?}")))?;
+
+    // Size, never the text: this file is handed to whoever is diagnosing a run,
+    // and the one thing a chat log must not leak is what was said.
+    tracing::info!("sent {} bytes to {convo_id}", content.len());
 
     let ts = now_ms();
     // Persist before emitting: the message is already on the wire, but if the
@@ -640,6 +646,13 @@ pub(crate) fn set_delivery_state(d: &mut Display, state: DeliveryStateKind, deta
         state,
         detail: detail.to_owned(),
     };
+    // The transitions, not the polling: this returns early while the state
+    // stands, so a line here is one thing actually changing.
+    match (state, detail) {
+        (DeliveryStateKind::Error, _) => tracing::error!("delivery failed: {detail}"),
+        (_, "") => tracing::info!("delivery is {}", state.as_str()),
+        _ => tracing::info!("delivery is {}: {detail}", state.as_str()),
+    }
     crate::emit_delivery_state_changed(state.as_str(), detail);
 }
 
@@ -656,11 +669,11 @@ pub(crate) fn record_conversation_started(convo_id: &str, kind: ConversationKind
         match with_client(|client| client.group_metadata(convo_id)) {
             Ok(Ok(meta)) => (non_empty(&meta.name), non_empty(&meta.desc)),
             Ok(Err(e)) => {
-                eprintln!("chat_module: group_metadata failed: {e:?}");
+                tracing::warn!("group_metadata failed: {e:?}");
                 (None, None)
             }
             Err(e) => {
-                eprintln!("chat_module: group_metadata: {e}");
+                tracing::warn!("group_metadata: {e}");
                 (None, None)
             }
         }
@@ -695,7 +708,7 @@ pub(crate) fn record_conversation_started(convo_id: &str, kind: ConversationKind
 
         // Event consumer has no caller to return to; log a failed write.
         if let Err(e) = save_display(d) {
-            eprintln!("chat_module: save_state failed after conversation started: {e}");
+            tracing::error!("save_state failed after conversation started: {e}");
         }
     });
 }
@@ -710,6 +723,11 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
         if d.state.deleted.contains(convo_id) {
             return;
         }
+        tracing::info!(
+            "received {} bytes in {convo_id} from {}",
+            content.len(),
+            short_label(sender)
+        );
         let text = String::from_utf8_lossy(content).to_string();
         let ts = now_ms();
         let session = d
@@ -736,7 +754,7 @@ pub(crate) fn record_message_received(convo_id: &str, content: &[u8], sender: &s
         crate::emit_message_received(convo_id, &text, ts as i64, sender);
 
         if let Err(e) = save_display(d) {
-            eprintln!("chat_module: save_state failed after inbound message: {e}");
+            tracing::error!("save_state failed after inbound message: {e}");
         }
     });
 }

--- a/rust-lib/src/delivery.rs
+++ b/rust-lib/src/delivery.rs
@@ -85,7 +85,7 @@ impl DeliveryService for SdkPublisher {
             .delivery_module
             .send_async(&topic, &envelope.data, move |res| {
                 if let Err(e) = res {
-                    eprintln!("chat_module: delivery_module.send failed: {e}");
+                    tracing::error!("delivery_module.send failed: {e}");
                 }
             });
         Ok(())

--- a/rust-lib/src/inbound.rs
+++ b/rust-lib/src/inbound.rs
@@ -101,7 +101,7 @@ fn run_bridge(
 fn forward_message(evt: &EventData, inbound_tx: &Sender<Vec<u8>>) {
     let Some(msg) = crate::delivery_module::DeliveryModuleClient::decode_message_received(evt)
     else {
-        eprintln!("chat_module inbound: messageReceived payload missing or malformed");
+        tracing::warn!("inbound: messageReceived payload missing or malformed");
         return;
     };
     if !msg.content_topic.starts_with(crate::delivery::TOPIC_PREFIX) {
@@ -125,7 +125,7 @@ fn forward_subscriptions(subscribe_rx: &Receiver<String>) {
             .delivery_module
             .subscribe_async(&topic, move |res| {
                 if let Err(e) = res {
-                    eprintln!("chat_module: delivery_module.subscribe failed: {e}");
+                    tracing::error!("delivery_module.subscribe failed: {e}");
                 }
             });
     }
@@ -154,7 +154,7 @@ fn run_events(events: Receiver<Event>) {
                 record_members_changed(&convo_id);
             }
             Event::InboundError { message } => {
-                eprintln!("chat_module: inbound error: {message}");
+                tracing::warn!("inbound error: {message}");
             }
             // `Event` is `#[non_exhaustive]`; ignore variants added upstream.
             _ => {}

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -35,6 +35,7 @@
 mod actions;
 mod delivery;
 mod inbound;
+mod logging;
 mod module;
 mod panic_hook;
 mod persistence;
@@ -73,6 +74,7 @@ struct ChatModuleImpl;
 impl ChatModule for ChatModuleImpl {
     fn init(&mut self, delivery_preset: String) -> Result<Value, String> {
         panic_hook::install_once();
+        logging::install_once();
 
         let preset = if delivery_preset.is_empty() {
             "logos.dev"

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -21,8 +21,8 @@
 //! `Result<serde_json::Value, String>`: `Ok(value)` carries any payload (a
 //! conversation id or `Null`), `Err(message)` a human-readable reason.
 //! Collection getters return `serde_json::Value` (a JSON array/object);
-//! `get_installation_name`/`get_address` return a plain string, empty when not
-//! initialised.
+//! `get_installation_name`/`get_address`/`get_log_path` return a plain string,
+//! empty when not initialised.
 //!
 //! Events reach consumers over the lp_* IPC channel: the operations below call
 //! the generated `emit_*` functions (see the included scaffold), which the host
@@ -65,6 +65,40 @@ pub(crate) use generated::*;
 /// exists only to satisfy the `result` return type.
 const ERR_LOCK_POISONED: &str = "internal error: module lock poisoned";
 
+/// The `ChatConfig` record `init` received, as the object its fields are read
+/// out of.
+///
+/// Two shapes arrive. A caller with a generated client sends an object. A caller
+/// using `logoscore call` sends the object's JSON *text*, because the CLI coerces
+/// an argument to a bool, a number or a string and never to an object — so a
+/// record parameter reaches a module as a string or not at all.
+fn chat_config(argument: Value) -> Value {
+    let Value::String(text) = &argument else {
+        return argument;
+    };
+    serde_json::from_str(text).unwrap_or_else(|_| {
+        // Said out loud: the argument before the record existed was the preset
+        // itself, so the alternative is joining the wrong delivery network in
+        // silence.
+        eprintln!(
+            "chat_module init: {text:?} is not a ChatConfig record; pass the \
+             record, or its JSON text. Every setting takes its default."
+        );
+        Value::Null
+    })
+}
+
+/// One field of a [`chat_config`] record.
+///
+/// The record materialises untyped — today's codegen has no generated struct for
+/// a record in parameter position — so every field is read out by hand and every
+/// one is optional. An empty string is what an absent field, a field of the wrong
+/// type, and a caller who sent no record at all all look like; each field's own
+/// default covers it.
+fn config_field<'a>(config: &'a Value, name: &str) -> &'a str {
+    config.get(name).and_then(Value::as_str).unwrap_or_default()
+}
+
 /// The `ChatModule` contract implementation. Stateless: all module state lives
 /// in the [`module`] singleton and the display lock, so every method delegates
 /// to `actions` (which own their locking) and `&mut self` is unused.
@@ -72,14 +106,14 @@ const ERR_LOCK_POISONED: &str = "internal error: module lock poisoned";
 struct ChatModuleImpl;
 
 impl ChatModule for ChatModuleImpl {
-    fn init(&mut self, delivery_preset: String) -> Result<Value, String> {
+    fn init(&mut self, config: Value) -> Result<Value, String> {
         panic_hook::install_once();
-        logging::install_once();
+        let config = chat_config(config);
+        logging::install_once(config_field(&config, "log_level"));
 
-        let preset = if delivery_preset.is_empty() {
-            "logos.dev"
-        } else {
-            delivery_preset.as_str()
+        let preset = match config_field(&config, "delivery_preset") {
+            "" => "logos.dev",
+            named => named,
         };
 
         match module().install_with(actions::initialize) {
@@ -115,6 +149,10 @@ impl ChatModule for ChatModuleImpl {
             actions::shutdown(ms);
         }
         Ok(Value::Null)
+    }
+
+    fn get_log_path(&mut self) -> String {
+        logging::log_path()
     }
 
     fn get_installation_name(&mut self) -> String {
@@ -197,4 +235,60 @@ impl ChatModule for ChatModuleImpl {
 #[no_mangle]
 pub extern "Rust" fn logos_module_install() {
     install::<ChatModuleImpl>();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A generated client sends the record as an object.
+    #[test]
+    fn a_record_is_read_field_by_field() {
+        let config = chat_config(serde_json::json!({
+            "delivery_preset": "logos.test",
+            "log_level": "debug",
+        }));
+
+        assert_eq!(config_field(&config, "delivery_preset"), "logos.test");
+        assert_eq!(config_field(&config, "log_level"), "debug");
+    }
+
+    /// `logoscore call` can only send the record as text, so the text is the
+    /// record.
+    #[test]
+    fn the_records_json_text_is_the_record() {
+        let config = chat_config(Value::String(
+            r#"{"delivery_preset":"logos.test"}"#.to_string(),
+        ));
+
+        assert_eq!(config_field(&config, "delivery_preset"), "logos.test");
+    }
+
+    /// Every field is optional, so a caller may configure one setting and leave
+    /// the rest alone.
+    #[test]
+    fn an_absent_field_reads_empty() {
+        let config = chat_config(serde_json::json!({ "log_level": "trace" }));
+
+        assert_eq!(config_field(&config, "delivery_preset"), "");
+        assert_eq!(config_field(&config, "log_level"), "trace");
+    }
+
+    /// What a caller from before the record sends: the preset on its own. It is
+    /// not a record, so it configures nothing — but it must not take the module
+    /// down on the way to finding that out.
+    #[test]
+    fn an_argument_that_is_no_record_configures_nothing() {
+        for argument in [
+            Value::String("logos.test".to_string()),
+            Value::Null,
+            serde_json::json!(3),
+            serde_json::json!(["logos.test"]),
+        ] {
+            let config = chat_config(argument);
+
+            assert_eq!(config_field(&config, "delivery_preset"), "");
+            assert_eq!(config_field(&config, "log_level"), "");
+        }
+    }
 }

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -85,6 +85,7 @@ impl ChatModule for ChatModuleImpl {
         match module().install_with(actions::initialize) {
             Err(_) => Err(ERR_LOCK_POISONED.to_string()),
             Ok(Ok(InstallOutcome::Installed)) => {
+                tracing::info!("init: state installed, joining delivery preset {preset}");
                 // State is installed and the module lock is released; only now
                 // bootstrap delivery, so its async completion callbacks acquire
                 // a free lock instead of re-entering the one init holds.
@@ -92,14 +93,14 @@ impl ChatModule for ChatModuleImpl {
                 Ok(Value::Null)
             }
             Ok(Ok(InstallOutcome::AlreadyInstalled)) => {
-                eprintln!(
-                    "chat_module init: already initialised; any new arguments are \
-                     ignored, call shutdown() first to reconfigure"
+                tracing::warn!(
+                    "init: already initialised; any new arguments are ignored, \
+                     call shutdown() first to reconfigure"
                 );
                 Ok(Value::Null)
             }
             Ok(Err(e)) => {
-                eprintln!("chat_module init: {e}");
+                tracing::error!("init: {e}");
                 Err(e.to_string())
             }
         }

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -155,6 +155,13 @@ impl ChatModule for ChatModuleImpl {
         logging::log_path()
     }
 
+    /// Touches no state and takes no lock: a probe that could block would report
+    /// a busy module as a dead one, and the process answering is the whole
+    /// answer. Deliberately silent, since a caller polls this.
+    fn health(&mut self) -> bool {
+        true
+    }
+
     fn get_installation_name(&mut self) -> String {
         actions::installation_name()
     }

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -1,0 +1,27 @@
+//! `tracing` subscriber installed on first init.
+//!
+//! libchat logs exclusively through `tracing`, and a `tracing` event emitted in
+//! a process with no subscriber installed is dropped. Install one writing to
+//! stderr, where the module's own diagnostics already go, so the chat stack's
+//! own account of a failure is available next to them.
+
+use std::sync::Once;
+
+use tracing_subscriber::EnvFilter;
+
+static INSTALL: Once = Once::new();
+
+/// Routes `tracing` events to stderr at the level `RUST_LOG` selects, `warn`
+/// when it is unset or unparseable.
+pub(crate) fn install_once() {
+    INSTALL.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+        // The output lands in pipes and rotating log files, where ANSI escapes
+        // are noise. `try_init` leaves an already-installed subscriber alone.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .with_ansi(false)
+            .try_init();
+    });
+}

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -11,11 +11,25 @@ use tracing_subscriber::EnvFilter;
 
 static INSTALL: Once = Once::new();
 
-/// Routes `tracing` events to stderr at the level `RUST_LOG` selects, `warn`
-/// when it is unset or unparseable.
+/// Everything at `warn`, and the chat core's own targets at `info`.
+///
+/// A flat `info` is the wrong shape here: the dependency graph carries crates
+/// far chattier than the chat core at that level (de-mls alone has an order of
+/// magnitude more `info` sites than libchat, most of them per-consensus-round),
+/// and they would bury the handful of lifecycle events this exists to surface.
+///
+/// `chat_module` is one of the targets because most of a run's story is this
+/// module's own: libchat and the generic client together raise eleven events,
+/// nearly all on failure paths, so a healthy run through them alone says
+/// nothing.
+const DEFAULT_FILTER: &str = "warn,chat_module=info,libchat=info,logos_generic_chat=info";
+
+/// Routes `tracing` events to stderr at the level `RUST_LOG` selects,
+/// [`DEFAULT_FILTER`] when it is unset or unparseable.
 pub(crate) fn install_once() {
     INSTALL.call_once(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
         // The output lands in pipes and rotating log files, where ANSI escapes
         // are noise. `try_init` leaves an already-installed subscriber alone.
         let _ = tracing_subscriber::fmt()
@@ -24,4 +38,29 @@ pub(crate) fn install_once() {
             .with_ansi(false)
             .try_init();
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `EnvFilter::new` drops a directive it cannot parse instead of failing, so
+    /// a typo in a target name would silently leave that target at the global
+    /// level.
+    #[test]
+    fn every_default_directive_parses() {
+        let parsed = EnvFilter::new(DEFAULT_FILTER).to_string();
+        let mut kept: Vec<_> = parsed.split(',').map(str::trim).collect();
+        kept.sort_unstable();
+
+        assert_eq!(
+            kept,
+            [
+                "chat_module=info",
+                "libchat=info",
+                "logos_generic_chat=info",
+                "warn"
+            ]
+        );
+    }
 }

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -2,48 +2,164 @@
 //!
 //! libchat logs exclusively through `tracing`, and a `tracing` event emitted in
 //! a process with no subscriber installed is dropped. Install one writing to
-//! stderr, where the module's own diagnostics already go, so the chat stack's
-//! own account of a failure is available next to them.
+//! two places: stderr, where the module's own diagnostics already go, so the
+//! chat stack's own account of a failure is available next to them; and a file
+//! in the instance directory the host assigned, which is what a consumer can
+//! hand over after the run is over.
 
+use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::Once;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, Once, OnceLock};
 
+use chrono::Local;
 use tracing_core::{Event, Level, Subscriber};
 use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, MakeWriter};
+use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 static INSTALL: Once = Once::new();
 
-/// Everything at `warn`, and the chat core's own targets at `info`.
+/// The file [`install_once`] opened, for [`log_path`] to report. Empty until
+/// then, and empty for good when there was nowhere to write.
+static LOG_PATH: Mutex<String> = Mutex::new(String::new());
+
+/// The same file the subscriber writes, for [`write_line`] to reach without it.
+static RUN_LOG: OnceLock<RunLog> = OnceLock::new();
+
+/// The level the chat core's own targets log at when the client named none.
+const DEFAULT_LEVEL: &str = "info";
+
+/// The name every log in an instance directory follows: `<stem>_<stamp>.log` is
+/// the file being written, `<stem>_<stamp>.NNN.log` a rotation of it. A consumer
+/// groups a directory's files into runs by reading this shape, and reads the
+/// stem off the announced path, so a second writer keeping its own log in the
+/// same directory is grouped separately without either knowing about the other.
+const STEM: &str = "chat_module";
+const STAMP_FORMAT: &str = "%Y%m%d_%H%M%S";
+/// The time a file line leads with. ISO-8601 to the millisecond, which is what
+/// reading this log against another writer's takes.
+const LINE_TIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f";
+/// Length of a [`STAMP_FORMAT`] stamp: eight date digits, a separator, six time
+/// digits.
+const STAMP_LEN: usize = 15;
+/// Lines before the file being written is moved aside and a fresh one opened.
+const ROTATE_AFTER_LINES: u64 = 10_000;
+/// Runs kept in the instance directory. That directory is persistence, so
+/// nothing else sweeps it and the module prunes its own.
+const KEEP_RUNS: usize = 10;
+
+/// Everything at `warn`, and the chat core's own targets at `level`.
 ///
-/// A flat `info` is the wrong shape here: the dependency graph carries crates
-/// far chattier than the chat core at that level (de-mls alone has an order of
-/// magnitude more `info` sites than libchat, most of them per-consensus-round),
-/// and they would bury the handful of lifecycle events this exists to surface.
+/// A flat level is the wrong shape here: the dependency graph carries crates far
+/// chattier than the chat core (de-mls alone has an order of magnitude more
+/// `info` sites than libchat, most of them per-consensus-round), and they would
+/// bury the handful of lifecycle events this exists to surface.
 ///
 /// `chat_module` is one of the targets because most of a run's story is this
 /// module's own: libchat and the generic client together raise eleven events,
 /// nearly all on failure paths, so a healthy run through them alone says
 /// nothing.
-const DEFAULT_FILTER: &str = "warn,chat_module=info,libchat=info,logos_generic_chat=info";
+fn filter_for(level: &str) -> String {
+    format!("warn,chat_module={level},libchat={level},logos_generic_chat={level}")
+}
 
-/// Routes `tracing` events to stderr at the level `RUST_LOG` selects,
-/// [`DEFAULT_FILTER`] when it is unset or unparseable.
-pub(crate) fn install_once() {
+/// The level a client may ask the chat core to log at. Anything else — absent,
+/// empty, misspelled — is [`DEFAULT_LEVEL`].
+fn level_or_default(requested: &str) -> &str {
+    match requested {
+        "error" | "warn" | "info" | "debug" | "trace" => requested,
+        _ => DEFAULT_LEVEL,
+    }
+}
+
+/// `RUST_LOG` outranks the client's choice, and neither an empty nor an
+/// unparseable value is a choice: `EnvFilter` reads `""` as "enable nothing",
+/// which would silence the stack a client asked to hear.
+fn filter_from(env: Option<&str>, level: &str) -> EnvFilter {
+    env.filter(|value| !value.trim().is_empty())
+        .and_then(|value| EnvFilter::try_new(value).ok())
+        .unwrap_or_else(|| EnvFilter::new(filter_for(level)))
+}
+
+/// The file this module is writing, empty when none was opened.
+pub(crate) fn log_path() -> String {
+    LOG_PATH.lock().expect("log path poisoned").clone()
+}
+
+/// Appends one already-formatted line to this run's log, bypassing `tracing`.
+///
+/// For what cannot go through the subscriber: the panic hook runs while the
+/// process is on its way to `abort`, and the thread that panicked may be the one
+/// holding the file. A busy file is skipped rather than waited on, because a
+/// deadlock here costs the whole record and one line is what is at stake.
+pub(crate) fn write_line(line: &str) {
+    if let Some(log) = RUN_LOG.get() {
+        log.write_stamped(line);
+    }
+}
+
+/// Routes `tracing` events to stderr and to this run's log file, at the level
+/// `RUST_LOG` selects, else the one the client asked for, else
+/// [`DEFAULT_LEVEL`].
+///
+/// The level is frozen here: `Once` plus `try_init` mean a second `init` changes
+/// nothing, which matches `init`'s own documented behaviour. Letting a client
+/// raise the level while running needs a `tracing_subscriber::reload` layer over
+/// the filter, and nothing asks for that yet.
+pub(crate) fn install_once(level: &str) {
     INSTALL.call_once(|| {
-        let filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+        let filter = filter_from(
+            std::env::var("RUST_LOG").ok().as_deref(),
+            level_or_default(level),
+        );
         let selected = filter.to_string();
+
+        let (run_log, opened) = match RunLog::open() {
+            Ok(log) => {
+                let path = log.path();
+                (log, path)
+            }
+            Err(reason) => {
+                eprintln!(
+                    "Warning: chat_module: no log file ({reason}); the chat \
+                     core's events reach stderr only"
+                );
+                (RunLog::inert(), String::new())
+            }
+        };
+        *LOG_PATH.lock().expect("log path poisoned") = opened.clone();
+        let _ = RUN_LOG.set(run_log.clone());
+        let destination = if opened.is_empty() {
+            "stderr".to_string()
+        } else {
+            format!("stderr and {opened}")
+        };
+
+        // Two destinations rather than one writer taking both, because the lines
+        // differ: what goes to stderr is re-emitted by a host that stamps it,
+        // and what goes to the file is stamped here or not at all.
+        //
         // Field formatting still consults the ANSI setting, and the output lands
         // in pipes and log files where escapes are noise. `try_init` leaves an
         // already-installed subscriber alone.
-        let installed = tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_writer(std::io::stderr)
+        let to_stderr = tracing_subscriber::fmt::layer()
+            .with_writer(io::stderr)
             .with_ansi(false)
-            .event_format(HostLine)
+            .event_format(HostLine);
+        let to_file = tracing_subscriber::fmt::layer()
+            .with_writer(run_log)
+            .with_ansi(false)
+            .event_format(StampedLine);
+        let installed = tracing_subscriber::registry()
+            .with(filter)
+            .with(to_stderr)
+            .with(to_file)
             .try_init();
         // Said in the module's own voice rather than through `tracing`, because
         // what it reports is whether `tracing` reaches anything at all. The
@@ -52,9 +168,11 @@ pub(crate) fn install_once() {
         // No `Debug:`/`Trace:` prefix on the success line: the host classifies a
         // module's stderr by exactly those keywords and its own logger sits at
         // info, so a line that names itself debug is dropped before it reaches
-        // the log. An unprefixed line lands at info.
+        // the log. An unprefixed line lands at info. That classifier reads the
+        // stderr half only — the file is written directly and passes nothing,
+        // which is what makes `debug` and `trace` worth asking for.
         match installed {
-            Ok(()) => eprintln!("chat_module: logging {selected}"),
+            Ok(()) => eprintln!("chat_module: logging {selected} to {destination}"),
             Err(error) => eprintln!(
                 "Warning: chat_module: another subscriber is already installed, \
                  the chat core's events will not be logged: {error}"
@@ -87,6 +205,30 @@ where
     }
 }
 
+/// [`HostLine`] with the time in front, for the file.
+///
+/// The file is written directly and nothing else stamps it, and a stamp is what
+/// reading this log against another writer's in the same directory takes. The
+/// stderr half stays unstamped: a host stamps what it re-emits, and two times on
+/// one line is noise.
+struct StampedLine;
+
+impl<S, N> FormatEvent<S, N> for StampedLine
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        write!(writer, "{} ", Local::now().format(LINE_TIME_FORMAT))?;
+        HostLine.format_event(ctx, writer, event)
+    }
+}
+
 /// The severity word a host ranks the line by.
 ///
 /// Hosts classify a module's stderr by a leading severity token, and the token
@@ -99,13 +241,208 @@ fn severity(level: &Level) -> &'static str {
     }
 }
 
+// ── The run's log file ───────────────────────────────────────────────────────
+
+/// The file this run writes its log to, shared with the subscriber, which writes
+/// from whichever thread raised the event. Holds nothing when there was nowhere
+/// to write, so the subscriber takes one writer either way.
+#[derive(Clone)]
+struct RunLog(Arc<Mutex<Option<OpenLog>>>);
+
+/// The file a run is writing, and what rotating it takes.
+struct OpenLog {
+    file: File,
+    /// The announced path, and always the file being written: a rotation moves
+    /// the full one aside and reopens under this name.
+    path: PathBuf,
+    stamp: String,
+    lines: u64,
+    rotations: u32,
+}
+
+impl RunLog {
+    /// Opens this run's file in the instance directory the host assigned, and
+    /// prunes all but the newest [`KEEP_RUNS`] runs.
+    fn open() -> Result<Self, String> {
+        // A host that never set a persistence base path still stamps a context,
+        // with the path left empty, so emptiness is the "host not configured"
+        // signal — the reading `actions::initialize` makes of the same field.
+        let directory = crate::context()
+            .map(|ctx| ctx.instance_persistence_path)
+            .filter(|path| !path.is_empty())
+            .ok_or("the host assigned no instance directory")?;
+        let directory = PathBuf::from(directory);
+        // This runs ahead of `actions::initialize`, which is what otherwise
+        // creates the directory, so on a first run it is not there yet.
+        fs::create_dir_all(&directory)
+            .map_err(|e| format!("cannot create {}: {e}", directory.display()))?;
+
+        let stamp = Local::now().format(STAMP_FORMAT).to_string();
+        let path = directory.join(format!("{STEM}_{stamp}.log"));
+        // Appending: two runs starting in the same second share a stamp, and the
+        // earlier one's lines are worth more than a tidy file.
+        let file = File::options()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+
+        // After opening, so the run about to be written is one of the ones kept.
+        prune_runs(&directory);
+
+        Ok(Self(Arc::new(Mutex::new(Some(OpenLog {
+            file,
+            path,
+            stamp,
+            lines: 0,
+            rotations: 0,
+        })))))
+    }
+
+    /// A log with nowhere to write: every line reaches stderr and stops there.
+    fn inert() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+
+    fn path(&self) -> String {
+        self.0
+            .lock()
+            .expect("run log poisoned")
+            .as_ref()
+            .map(|open| open.path.display().to_string())
+            .unwrap_or_default()
+    }
+
+    /// Appends one already-formatted line, stamped like every other. Skips a
+    /// busy file instead of waiting on it, which is what makes this safe to call
+    /// from a thread that may itself be the one holding it.
+    fn write_stamped(&self, line: &str) {
+        let Ok(mut open) = self.0.try_lock() else {
+            return;
+        };
+        if let Some(open) = open.as_mut() {
+            let stamped = format!("{} {line}\n", Local::now().format(LINE_TIME_FORMAT));
+            let _ = open.append(stamped.as_bytes());
+        }
+    }
+}
+
+impl OpenLog {
+    /// Appends one event's bytes, rotating once the file is full. The count is of
+    /// the lines this process wrote, so a run that reopens an existing stamp
+    /// carries on from whatever was already in the file.
+    fn append(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.file.write_all(buf)?;
+        self.lines += buf.iter().filter(|byte| **byte == b'\n').count() as u64;
+        if self.lines >= ROTATE_AFTER_LINES {
+            self.rotate()?;
+        }
+        Ok(())
+    }
+
+    /// Moves the full file aside under the next rotation ordinal and opens a
+    /// fresh one back under the announced name.
+    fn rotate(&mut self) -> io::Result<()> {
+        // Spend the budget before trying: a rotation that cannot happen has to
+        // be retried when the file is next full, not on every line after this
+        // one.
+        self.lines = 0;
+        self.rotations += 1;
+        let aside = self
+            .path
+            .with_file_name(format!("{STEM}_{}.{:03}.log", self.stamp, self.rotations));
+        fs::rename(&self.path, aside)?;
+        self.file = File::create(&self.path)?;
+        Ok(())
+    }
+}
+
+impl io::Write for RunLog {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.0.lock().expect("run log poisoned").as_mut() {
+            Some(open) => open.append(buf).map(|()| buf.len()),
+            None => Ok(buf.len()),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.0.lock().expect("run log poisoned").as_mut() {
+            Some(open) => open.file.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<'a> MakeWriter<'a> for RunLog {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Deletes every run in `directory` but the newest [`KEEP_RUNS`], rotations
+/// included.
+fn prune_runs(directory: &Path) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+
+    let mut runs: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(stamp) = name.to_str().and_then(stamp_of) else {
+            continue;
+        };
+        runs.entry(stamp.to_string())
+            .or_default()
+            .push(entry.path());
+    }
+
+    // A stamp sorts lexicographically the way it sorts chronologically, so the
+    // oldest runs are the front of the map.
+    let excess = runs.len().saturating_sub(KEEP_RUNS);
+    for (_, files) in runs.into_iter().take(excess) {
+        for file in files {
+            let _ = fs::remove_file(file);
+        }
+    }
+}
+
+/// The stamp a run file's name carries, or `None` when the name is not one of
+/// this module's — which is what leaves another writer's log in the same
+/// directory alone.
+fn stamp_of(file_name: &str) -> Option<&str> {
+    let rest = file_name.strip_prefix(STEM)?.strip_prefix('_')?;
+    let stamp = rest.get(..STAMP_LEN)?;
+    let (date, time) = stamp.split_once('_')?;
+    let digits = |part: &str| part.bytes().all(|byte| byte.is_ascii_digit());
+    if date.len() != 8 || time.len() != 6 || !digits(date) || !digits(time) {
+        return None;
+    }
+    is_run_suffix(&rest[STAMP_LEN..]).then_some(stamp)
+}
+
+/// Whether what follows a stamp names the file being written (`.log`) or one of
+/// its rotations (`.NNN.log`).
+fn is_run_suffix(suffix: &str) -> bool {
+    if suffix == ".log" {
+        return true;
+    }
+    let bytes = suffix.as_bytes();
+    bytes.len() == ".000.log".len()
+        && bytes[0] == b'.'
+        && suffix.ends_with(".log")
+        && bytes[1..4].iter().all(|byte| byte.is_ascii_digit())
+}
+
 #[cfg(test)]
 mod tests {
     use std::io;
     use std::sync::{Arc, Mutex};
 
+    use tempfile::TempDir;
     use tracing_core::Dispatch;
-    use tracing_subscriber::fmt::MakeWriter;
 
     use super::*;
 
@@ -145,17 +482,73 @@ mod tests {
         String::from_utf8(written).expect("the format writes text")
     }
 
+    fn stamped_line_for(emit: impl FnOnce()) -> String {
+        let sink = Captured::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_ansi(false)
+            .event_format(StampedLine)
+            .finish();
+        tracing_core::dispatcher::with_default(&Dispatch::new(subscriber), emit);
+
+        let written = sink.0.lock().expect("sink poisoned").clone();
+        String::from_utf8(written).expect("the format writes text")
+    }
+
+    /// A log open in `directory` under a fixed stamp, so a test can name the
+    /// files it expects rather than reading the clock.
+    fn log_at(directory: &Path, stamp: &str) -> RunLog {
+        let path = directory.join(format!("{STEM}_{stamp}.log"));
+        let file = File::options()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .expect("the temporary directory is writable");
+        RunLog(Arc::new(Mutex::new(Some(OpenLog {
+            file,
+            path,
+            stamp: stamp.to_string(),
+            lines: 0,
+            rotations: 0,
+        }))))
+    }
+
+    fn write_lines(log: &mut RunLog, count: u64) {
+        for _ in 0..count {
+            io::Write::write_all(log, b"INFO: libchat: something happened\n")
+                .expect("the temporary directory is writable");
+        }
+    }
+
+    /// `EnvFilter` reports the directives it kept in an order of its own, so a
+    /// filter is compared as a set rather than as the string it was built from.
+    fn directives(filter: EnvFilter) -> Vec<String> {
+        let mut kept: Vec<String> = filter
+            .to_string()
+            .split(',')
+            .map(|directive| directive.trim().to_string())
+            .collect();
+        kept.sort();
+        kept
+    }
+
+    fn file_names(directory: &Path) -> Vec<String> {
+        let mut names: Vec<String> = fs::read_dir(directory)
+            .expect("the temporary directory is readable")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
     /// `EnvFilter::new` drops a directive it cannot parse instead of failing, so
     /// a typo in a target name would silently leave that target at the global
     /// level.
     #[test]
     fn every_default_directive_parses() {
-        let parsed = EnvFilter::new(DEFAULT_FILTER).to_string();
-        let mut kept: Vec<_> = parsed.split(',').map(str::trim).collect();
-        kept.sort_unstable();
-
         assert_eq!(
-            kept,
+            directives(EnvFilter::new(filter_for(DEFAULT_LEVEL))),
             [
                 "chat_module=info",
                 "libchat=info",
@@ -163,6 +556,56 @@ mod tests {
                 "warn"
             ]
         );
+    }
+
+    /// The whole ladder is available, and only the chat core's targets move: a
+    /// client asking for `trace` must not uncap the crates around it.
+    #[test]
+    fn every_level_applies_to_the_chat_core_and_nothing_else() {
+        for level in ["error", "warn", "info", "debug", "trace"] {
+            assert_eq!(
+                directives(filter_from(None, level_or_default(level))),
+                [
+                    format!("chat_module={level}"),
+                    format!("libchat={level}"),
+                    format!("logos_generic_chat={level}"),
+                    "warn".to_string()
+                ],
+                "{level} must reach the chat core's targets alone"
+            );
+        }
+    }
+
+    /// A level nobody recognises is not a reason to log nothing, or everything.
+    #[test]
+    fn an_unusable_level_is_the_default_one() {
+        for requested in ["", "verbose", "INFO", "9"] {
+            assert_eq!(level_or_default(requested), DEFAULT_LEVEL);
+        }
+    }
+
+    /// The environment outranks the client, because a developer with `RUST_LOG`
+    /// set is overriding the app on purpose.
+    #[test]
+    fn rust_log_wins_over_the_clients_level() {
+        assert_eq!(
+            directives(filter_from(Some("libchat=trace"), "error")),
+            ["libchat=trace"]
+        );
+    }
+
+    /// An empty `RUST_LOG` is what an unset one looks like to a shell that
+    /// exported it anyway, and `EnvFilter` reads it as "enable nothing" — which
+    /// would silence the stack rather than leave it as the client asked.
+    #[test]
+    fn an_empty_or_unusable_rust_log_is_no_choice_at_all() {
+        for env in ["", "   ", "libchat=nonsense"] {
+            assert_eq!(
+                directives(filter_from(Some(env), "debug")),
+                directives(EnvFilter::new(filter_for("debug"))),
+                "{env:?} must leave the client's level standing"
+            );
+        }
     }
 
     /// A host reads severity off a token, and only `WARNING` names that level;
@@ -186,5 +629,169 @@ mod tests {
             line,
             "WARNING: chat_module::logging::tests: wakeup failed convo=3f2a\n"
         );
+    }
+
+    /// The file is the only record of its own lines, so each one carries the
+    /// time; what follows is the line stderr gets.
+    #[test]
+    fn a_file_line_leads_with_the_time() {
+        let line = stamped_line_for(|| tracing::warn!("wakeup failed"));
+        let (stamp, rest) = line.split_once(' ').expect("a time, then the line");
+
+        assert!(
+            chrono::NaiveDateTime::parse_from_str(stamp, LINE_TIME_FORMAT).is_ok(),
+            "{stamp} does not read as a time"
+        );
+        assert_eq!(
+            rest,
+            "WARNING: chat_module::logging::tests: wakeup failed\n"
+        );
+    }
+
+    /// The panic hook's route in. A crash is the failure the file exists for and
+    /// the one thing that cannot arrive as a `tracing` event, so it goes to the
+    /// file directly, and stamped like everything around it.
+    #[test]
+    fn a_line_written_outside_tracing_is_stamped_like_the_rest() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let log = log_at(directory.path(), "20260730_120000");
+
+        log.write_stamped("CRITICAL: chat_module: panic at group_v1.rs:340:14: boom");
+
+        let written = fs::read_to_string(directory.path().join("chat_module_20260730_120000.log"))
+            .expect("the line was written");
+        let (stamp, rest) = written.split_once(' ').expect("a time, then the line");
+        assert!(
+            chrono::NaiveDateTime::parse_from_str(stamp, LINE_TIME_FORMAT).is_ok(),
+            "{stamp} does not read as a time"
+        );
+        assert_eq!(
+            rest,
+            "CRITICAL: chat_module: panic at group_v1.rs:340:14: boom\n"
+        );
+    }
+
+    /// The panicking thread may be the one holding the file. Waiting for it
+    /// would trade the one line for the whole record, so the line is what gives.
+    #[test]
+    fn a_busy_file_costs_the_line_and_not_the_process() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let log = log_at(directory.path(), "20260730_120000");
+        let held = log.0.lock().expect("run log poisoned");
+
+        log.write_stamped("CRITICAL: chat_module: panic while holding the file");
+
+        drop(held);
+        assert_eq!(
+            fs::read_to_string(directory.path().join("chat_module_20260730_120000.log"))
+                .expect("the file is readable"),
+            ""
+        );
+    }
+
+    /// A log with nowhere to write is still a writer, so the subscriber needs no
+    /// second shape for the case where the host assigned no directory.
+    #[test]
+    fn a_log_with_nowhere_to_write_swallows_its_lines() {
+        let mut inert = RunLog::inert();
+
+        write_lines(&mut inert, 3);
+
+        assert!(inert.path().is_empty());
+    }
+
+    /// The announced path is what a consumer lists a directory from, so it has to
+    /// keep naming the file being written once the first one fills.
+    #[test]
+    fn a_full_file_is_moved_aside_and_the_announced_path_reopened() {
+        let directory = TempDir::new().expect("a temporary directory");
+        let mut log = log_at(directory.path(), "20260730_142811");
+        let announced = log.path();
+
+        write_lines(&mut log, ROTATE_AFTER_LINES);
+
+        assert_eq!(log.path(), announced, "the announced path does not move");
+        assert_eq!(
+            file_names(directory.path()),
+            [
+                "chat_module_20260730_142811.001.log",
+                "chat_module_20260730_142811.log"
+            ]
+        );
+        assert_eq!(
+            fs::read_to_string(&announced)
+                .expect("the reopened file is readable")
+                .len(),
+            0,
+            "the reopened file starts empty"
+        );
+    }
+
+    /// Rotations of one run are that run, so pruning counts stamps and takes a
+    /// run's whole set of files with it.
+    #[test]
+    fn pruning_keeps_ten_runs_and_counts_a_runs_rotations_as_one() {
+        let directory = TempDir::new().expect("a temporary directory");
+        for day in 1..=12 {
+            let stamp = format!("202607{day:02}_120000");
+            for name in [
+                format!("{STEM}_{stamp}.log"),
+                format!("{STEM}_{stamp}.001.log"),
+            ] {
+                File::create(directory.path().join(name)).expect("writable");
+            }
+        }
+        // Another writer's log in the same directory, and a file that only looks
+        // like a run.
+        File::create(directory.path().join("chat_ui_20260701_120000.log")).expect("writable");
+        File::create(directory.path().join("chat_module_notastamp.log")).expect("writable");
+
+        prune_runs(directory.path());
+
+        let kept = file_names(directory.path());
+        assert_eq!(kept.len(), 10 * 2 + 2, "ten runs, and neither stranger");
+        assert!(
+            kept.contains(&"chat_ui_20260701_120000.log".to_string()),
+            "another writer's log is not this module's to delete"
+        );
+        assert!(
+            kept.contains(&"chat_module_notastamp.log".to_string()),
+            "a file carrying no stamp belongs to no run"
+        );
+
+        // `file_names` sorts, so a run's files are adjacent and the oldest kept
+        // stamp comes first.
+        let mut stamps: Vec<&str> = kept.iter().filter_map(|name| stamp_of(name)).collect();
+        stamps.dedup();
+        assert_eq!(stamps.len(), KEEP_RUNS);
+        assert_eq!(
+            stamps.first().copied(),
+            Some("20260703_120000"),
+            "the two oldest runs go, both of their files each"
+        );
+    }
+
+    /// Grouping a directory into runs reads the stem, so what a name has to say
+    /// to be one of ours is worth pinning.
+    #[test]
+    fn only_this_modules_run_files_carry_a_stamp() {
+        assert_eq!(
+            stamp_of("chat_module_20260730_142811.log"),
+            Some("20260730_142811")
+        );
+        assert_eq!(
+            stamp_of("chat_module_20260730_142811.007.log"),
+            Some("20260730_142811")
+        );
+        for stranger in [
+            "chat_ui_20260730_142811.log",
+            "chat_module_20260730_142811.log.bak",
+            "chat_module_2026073_142811.log",
+            "chat_module_20260730_14281x.log",
+            "chat_module_20260730_142811.7.log",
+            "chat_module.log",
+        ] {
+            assert_eq!(stamp_of(stranger), None, "{stranger} is not one of ours");
+        }
     }
 }

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -5,8 +5,13 @@
 //! stderr, where the module's own diagnostics already go, so the chat stack's
 //! own account of a failure is available next to them.
 
+use std::fmt;
 use std::sync::Once;
 
+use tracing_core::{Event, Level, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
 
 static INSTALL: Once = Once::new();
@@ -30,19 +35,99 @@ pub(crate) fn install_once() {
     INSTALL.call_once(|| {
         let filter =
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
-        // The output lands in pipes and rotating log files, where ANSI escapes
-        // are noise. `try_init` leaves an already-installed subscriber alone.
+        // Field formatting still consults the ANSI setting, and the output lands
+        // in pipes and log files where escapes are noise. `try_init` leaves an
+        // already-installed subscriber alone.
         let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_writer(std::io::stderr)
             .with_ansi(false)
+            .event_format(HostLine)
             .try_init();
     });
 }
 
+/// `<SEVERITY>: <target>: <message>`, one line per event.
+///
+/// Carries no timestamp: every line reaches a reader through a host that stamps
+/// what it re-emits, and a second time on the same line is noise.
+struct HostLine;
+
+impl<S, N> FormatEvent<S, N> for HostLine
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let meta = event.metadata();
+        write!(writer, "{}: {}: ", severity(meta.level()), meta.target())?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+/// The severity word a host ranks the line by.
+///
+/// Hosts classify a module's stderr by a leading severity token, and the token
+/// for a warning is `WARNING`, which is not what `tracing` calls that level.
+fn severity(level: &Level) -> &'static str {
+    if *level == Level::WARN {
+        "WARNING"
+    } else {
+        level.as_str()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    use tracing_core::Dispatch;
+    use tracing_subscriber::fmt::MakeWriter;
+
     use super::*;
+
+    /// Collects everything a subscriber writes, so a test can read the line back.
+    #[derive(Clone, Default)]
+    struct Captured(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for Captured {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("sink poisoned").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for Captured {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn line_for(emit: impl FnOnce()) -> String {
+        let sink = Captured::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_ansi(false)
+            .event_format(HostLine)
+            .finish();
+        tracing_core::dispatcher::with_default(&Dispatch::new(subscriber), emit);
+
+        let written = sink.0.lock().expect("sink poisoned").clone();
+        String::from_utf8(written).expect("the format writes text")
+    }
 
     /// `EnvFilter::new` drops a directive it cannot parse instead of failing, so
     /// a typo in a target name would silently leave that target at the global
@@ -61,6 +146,29 @@ mod tests {
                 "logos_generic_chat=info",
                 "warn"
             ]
+        );
+    }
+
+    /// A host reads severity off a token, and only `WARNING` names that level;
+    /// `tracing`'s own spelling would be ranked as an ordinary line.
+    #[test]
+    fn every_level_names_itself_the_way_a_host_reads_it() {
+        assert_eq!(severity(&Level::ERROR), "ERROR");
+        assert_eq!(severity(&Level::WARN), "WARNING");
+        assert_eq!(severity(&Level::INFO), "INFO");
+        assert_eq!(severity(&Level::DEBUG), "DEBUG");
+        assert_eq!(severity(&Level::TRACE), "TRACE");
+    }
+
+    /// The line is what a reader downstream parses, so its shape is a contract:
+    /// severity, then the emitting target, then the message and its fields.
+    #[test]
+    fn a_line_leads_with_its_severity_then_its_target() {
+        let line = line_for(|| tracing::warn!(convo = %"3f2a", "wakeup failed"));
+
+        assert_eq!(
+            line,
+            "WARNING: chat_module::logging::tests: wakeup failed convo=3f2a\n"
         );
     }
 }

--- a/rust-lib/src/logging.rs
+++ b/rust-lib/src/logging.rs
@@ -35,15 +35,31 @@ pub(crate) fn install_once() {
     INSTALL.call_once(|| {
         let filter =
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+        let selected = filter.to_string();
         // Field formatting still consults the ANSI setting, and the output lands
         // in pipes and log files where escapes are noise. `try_init` leaves an
         // already-installed subscriber alone.
-        let _ = tracing_subscriber::fmt()
+        let installed = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_writer(std::io::stderr)
             .with_ansi(false)
             .event_format(HostLine)
             .try_init();
+        // Said in the module's own voice rather than through `tracing`, because
+        // what it reports is whether `tracing` reaches anything at all. The
+        // failure is silent otherwise: the chat core's events go on being raised
+        // and dropped, and a reader has no way to tell that from a quiet stack.
+        // No `Debug:`/`Trace:` prefix on the success line: the host classifies a
+        // module's stderr by exactly those keywords and its own logger sits at
+        // info, so a line that names itself debug is dropped before it reaches
+        // the log. An unprefixed line lands at info.
+        match installed {
+            Ok(()) => eprintln!("chat_module: logging {selected}"),
+            Err(error) => eprintln!(
+                "Warning: chat_module: another subscriber is already installed, \
+                 the chat core's events will not be logged: {error}"
+            ),
+        }
     });
 }
 

--- a/rust-lib/src/panic_hook.rs
+++ b/rust-lib/src/panic_hook.rs
@@ -7,9 +7,16 @@
 //! code. What *does* run before abort is the panic hook: install one that
 //! prints location + payload to stderr so libchat crashes inside the
 //! `logos_host_qt` subprocess are locatable instead of an opaque SIGABRT.
+//!
+//! The same goes to this run's log file, with a backtrace. A crash is the
+//! failure a reader most needs the file for, and it is the one thing that cannot
+//! arrive as a `tracing` event: the process is already on its way down.
 
+use std::backtrace::Backtrace;
 use std::panic;
 use std::sync::Once;
+
+use crate::logging;
 
 static INSTALL: Once = Once::new();
 
@@ -23,15 +30,18 @@ pub(crate) fn install_once() {
                 .copied()
                 .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
                 .unwrap_or("<non-string panic payload>");
-            match info.location() {
-                Some(loc) => eprintln!(
-                    "chat_module: panic at {}:{}:{}: {msg}",
-                    loc.file(),
-                    loc.line(),
-                    loc.column()
-                ),
-                None => eprintln!("chat_module: panic at <unknown location>: {msg}"),
-            }
+            let origin = match info.location() {
+                Some(loc) => format!("{}:{}:{}", loc.file(), loc.line(), loc.column()),
+                None => "<unknown location>".to_string(),
+            };
+            eprintln!("chat_module: panic at {origin}: {msg}");
+            // Forced, not `capture`: this is the one line that has to carry a
+            // trace, and leaving it to `RUST_BACKTRACE` means the run that
+            // crashed is the run that did not record why.
+            logging::write_line(&format!(
+                "CRITICAL: chat_module: panic at {origin}: {msg}\n{}",
+                Backtrace::force_capture()
+            ));
             previous(info);
         }));
     });

--- a/rust-lib/src/persistence.rs
+++ b/rust-lib/src/persistence.rs
@@ -122,8 +122,8 @@ pub(crate) fn load_state(path: &Path) -> AppState {
     let contents = match fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!(
-                "chat_module: load_state: cannot read {}: {e}; starting with default state",
+            tracing::warn!(
+                "load_state: cannot read {}: {e}; starting with default state",
                 path.display()
             );
             return AppState::default();
@@ -141,15 +141,15 @@ pub(crate) fn load_state(path: &Path) -> AppState {
                 .unwrap_or(0);
             let bad = path.with_extension(format!("json.bad.{suffix}"));
             if let Err(rename_err) = fs::rename(path, &bad) {
-                eprintln!(
-                    "chat_module: load_state: parse failure on {}: {e}; \
+                tracing::error!(
+                    "load_state: parse failure on {}: {e}; \
                      ALSO failed to move corrupt file aside ({rename_err}); \
-                     starting with default state — next save will overwrite",
+                     starting with default state, and the next save overwrites it",
                     path.display()
                 );
             } else {
-                eprintln!(
-                    "chat_module: load_state: parse failure on {}: {e}; \
+                tracing::warn!(
+                    "load_state: parse failure on {}: {e}; \
                      corrupt file moved to {}; starting with default state",
                     path.display(),
                     bad.display()


### PR DESCRIPTION
### feat: install a tracing subscriber so libchat's logs are visible

libchat logs exclusively through `tracing`, and an event emitted in a process with no subscriber installed is dropped, so nothing the chat stack logged from inside the module process ever reached the host's log.

The default level is `warn` rather than `off`, following chat-cli: quiet in normal operation, while the warnings and errors that motivated this surface without setting anything.

### feat: default the chat core's targets to info, this module included

A subscriber at `warn` leaves the chat core effectively silent: at the pinned rev libchat's conversation core and the threaded client raise eleven events between them, nearly all on paths that are already failing, so a run that merely behaves oddly writes nothing at all.

Raise those targets rather than the whole graph. A flat `info` would pull in crates well below the chat core, de-mls most of all, whose per-consensus-round output at that level dwarfs what libchat writes and would bury it.

Raising them is not enough on its own. The `info` events that would explain an odd run, a group waking, the convo cache being rebuilt, a welcome being processed, each need a peer or an inbound message to fire, and this module raised none of its own, so an ordinary run still wrote nothing. Most of a run's story is the module's, and it now tells it on the same channel and under the same filter: init, every delivery-state transition, a conversation created, a message sent or received. Its existing diagnostics move from `eprintln!` to `tracing` for the same reason, so they rank by severity and carry a target rather than arriving as unranked stderr.

Messages log a byte count and a conversation id, never content.

### feat: name the severity and the target on every log line

A host ranks a module's stderr by a leading severity token and stamps what it re-emits, so tracing's default line arrived unranked (its level word carries no token) and doubly timestamped. Emitting `<SEVERITY>: <target>: <message>` lets a reader downstream take the level from the host's own column and the domain from the target.

### feat: say whether the subscriber was installed

`try_init` reports a subscriber already claiming the global slot, and discarding that leaves the chat core's events raised and dropped with nothing to distinguish that from a quiet stack.

Said through `eprintln!` rather than `tracing`, since what it reports is whether `tracing` reaches anything at all, and without a `Debug:` prefix, which the host classifies below the level its own logger keeps.

### feat: keep the chat core's log in the instance directory

The module's account of a run only existed on stderr, where the host classifies by keyword and drops whatever ranks below its own level, so asking for debug or trace changed nothing and nothing could name a file to hand over afterwards. It now writes chat_module_<stamp>.log into the instance directory the host assigns, rotating at 10000 lines and keeping ten runs, and names it through get_log_path(). The file passes no classifier, so the level a client asks for is the level it gets.

A crash is the failure that file is most worth having, and the one thing that cannot arrive as a tracing event: under panic = "abort" the process is already on its way down. The panic hook writes it there itself, with a forced backtrace rather than one RUST_BACKTRACE has to have been set for, since the run that crashed is otherwise the run that did not record why. It takes the file with try_lock, because the panicking thread may be the one holding it and waiting there would trade the line for the whole record.

init takes a ChatConfig record instead of the bare preset, because LIDL has no optional method parameters and widening the arity would make every existing caller dispatch to nothing. logoscore call cannot send an object, coercing every argument to a bool, a number or a string, so init reads the record's JSON text too and reports an argument that is neither rather than defaulting it in silence.

The contract signature changes and the version intentionally does not.

### feat: answer whether this module is still there

A module that dies takes no part in noticing, and nothing else reports it either: the host logs the crash to its own output, but no consumer-facing type carries a signal a view could subscribe to. A consumer finds out when the next thing it does runs out its own timeout, twenty seconds later, having looked connected the whole time. An idle one never finds out at all.

health() answers true and nothing else, so what a caller learns is whether the call arrived. It needs no init and takes no lock, because a probe that could block would report a busy module as a dead one, and it says nothing to the log, because something polls it.

---

Supersedes #50, whose single commit is this branch's first, rebased: `rust-lib/src/logging.rs` is byte-identical between the two.
