### PR TITLE
build: name delivery_module without a version constraint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,9 @@
   };
 
   inputs = {
-    # Pinned to the 0.2.6 release, whose host reads a dependency entry written
-    # in object form (logos-module 9fb81c5, reached through logos-standalone-app
-    # and liblogos). An older host drops such an entry and never loads what it
-    # names.
+    # Held at the 0.2.6 release rather than master: master carries a
+    # logos-rust-sdk whose lidl-gen emits declared records as typed Rust
+    # structs, which this module's providers are not written against.
     logos-module-builder.url = "github:logos-co/logos-module-builder/0.2.6";
 
     # Pinned to the v0.1.3 release tag, which includes the zerokit/RLN nix

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "interface": "cdylib",
   "category": "chat",
   "main": "chat_module_plugin",
-  "dependencies": [{ "name": "delivery_module", "version": "=0.1.3" }],
+  "dependencies": ["delivery_module"],
   "include": [],
   "capabilities": [],
 


### PR DESCRIPTION
`metadata.json` declares `delivery_module` by name again, dropping the `=0.1.3` constraint 0.2.1 introduced.

A version constraint has to be written as an object entry, `{"name": …, "version": …}`, and a host only sees it if it was built after the loader fix in logos-module 9fb81c5. An older host reads the entry as an empty name, skips it, and loads this module without the dependency it names, with nothing in the log to say so. The C++ generator that builds a `ui_qml` view's backend has the same gap (logos-cpp-sdk#123, open), which is what stops logos-chat-ui from declaring its own dependency on this module at an exact version.

The constraint goes back once every reader has the fix. Nothing else about 0.2.1 changes; the builder stays at its 0.2.6 release, with its comment now saying what actually holds it there.