### PR TITLE
Default the delivery preset to logos.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ flake pins [`logos-delivery-module`](https://github.com/logos-co/logos-delivery-
 at `v0.1.3`. Load `chat_module` via `logoscore` or Basecamp.
 
 Bring-up is `init(config)`, taking a `ChatConfig` record whose every field is
-optional: `delivery_preset` (empty or absent → `logos.dev`) and `log_level`.
+optional: `delivery_preset` (empty or absent → `logos.test`) and `log_level`.
 `init` starts delivery asynchronously and returns immediately; readiness arrives
 later as a `delivery_state_changed` event reaching `online`. State is written to
 the instance directory the host assigns, so running two instances side by side

--- a/rust-lib/chat_module.lidl
+++ b/rust-lib/chat_module.lidl
@@ -59,7 +59,7 @@ module chat_module {
 
   ; --- lifecycle ---
   type ChatConfig {
-    ; The delivery network to join. Empty or absent means "logos.dev".
+    ; The delivery network to join. Empty or absent means "logos.test".
     ? delivery_preset: tstr
     ; How much of the chat core's own account of a run to log:
     ; "error" | "warn" | "info" | "debug" | "trace". Absent or unrecognised

--- a/rust-lib/src/lib.rs
+++ b/rust-lib/src/lib.rs
@@ -112,7 +112,7 @@ impl ChatModule for ChatModuleImpl {
         logging::install_once(config_field(&config, "log_level"));
 
         let preset = match config_field(&config, "delivery_preset") {
-            "" => "logos.dev",
+            "" => "logos.test",
             named => named,
         };
 


### PR DESCRIPTION
`init` resolves an empty or absent `delivery_preset` to `logos.dev`. Every documented bring-up — the two doctests, the chat-ui, the module procedure doc — passes `logos.test` explicitly, so the default is the one network nobody asks for. This makes the default the fleet consumers actually reach for; naming a preset still wins.

Three sites, one value each: the resolution in `init`, the `ChatConfig` comment in the `.lidl` contract, and the README's bring-up paragraph.

The doctests keep passing `delivery_preset` explicitly — redundant now, but it keeps the documented invocation readable to someone who has not read this diff.

Verified: `cargo check` clean, 32 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)